### PR TITLE
Adapt devops for public use

### DIFF
--- a/.github/scripts/delete_containers_not_matching_remote_branches.py
+++ b/.github/scripts/delete_containers_not_matching_remote_branches.py
@@ -33,7 +33,7 @@ def main(package_name: str, dry_run: bool) -> None:
 
     # first fetch a list of all docker images (as well as other information) from the repository
     all_docker_images = subprocess.check_output(
-        'gcloud artifacts docker images list europe-west1-docker.pkg.dev/glambie-0/dr', shell=True
+        'gcloud artifacts docker images list europe-west1-docker.pkg.dev/glambie/dr', shell=True
     ).decode().split("\n")[1:-1]  # strip off header and trailing newline with indexing
 
     # extract only the docker image names related to this package

--- a/.github/test_env_dockerfile
+++ b/.github/test_env_dockerfile
@@ -30,4 +30,4 @@ RUN conda run --name ${PACKAGE_NAME} pip install -r .github/test_requirements.tx
 # install the package's requirements, including Earthwave dependencies.
 COPY requirements.txt requirements.txt
 RUN conda run --name ${PACKAGE_NAME} pip install -r requirements.txt \
-    --extra-index-url https://europe-west1-python.pkg.dev/glambie-0/pr/simple/ --use-deprecated=legacy-resolver
+    --extra-index-url https://europe-west1-python.pkg.dev/glambie/pr/simple/ --use-deprecated=legacy-resolver

--- a/.github/workflows/generic_build_container_if_needed.yml
+++ b/.github/workflows/generic_build_container_if_needed.yml
@@ -48,12 +48,12 @@ jobs:
       - name: Define container name
         id: name_container
         run: |
-          echo "::set-output name=image_name::europe-west1-docker.pkg.dev/glambie-0/dr/${{ inputs.package_name }}_$(echo "$GITHUB_REF_NAME" | awk '{print tolower($0)}')"     
+          echo "::set-output name=image_name::europe-west1-docker.pkg.dev/glambie/dr/${{ inputs.package_name }}_$(echo "$GITHUB_REF_NAME" | awk '{print tolower($0)}')"     
 
       - name: Check if container already exists
         id: check_container
         run: |
-          gcloud artifacts docker images list europe-west1-docker.pkg.dev/glambie-0/dr | grep "${{ steps.name_container.outputs.image_name }}"
+          gcloud artifacts docker images list europe-west1-docker.pkg.dev/glambie/dr | grep "${{ steps.name_container.outputs.image_name }}"
           echo "::set-output name=exists::$?"
 
       - name: Check if package requirements changed

--- a/.github/workflows/generic_deploy.yml
+++ b/.github/workflows/generic_deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - id: specify
         run: |
-          echo "::set-output name=image_name::europe-west1-docker.pkg.dev/glambie-0/dr/${{ inputs.package_name }}_main"
+          echo "::set-output name=image_name::europe-west1-docker.pkg.dev/glambie/dr/${{ inputs.package_name }}_main"
     outputs:
       image_name: ${{ steps.specify.outputs.image_name }}
 
@@ -112,14 +112,14 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          body: "This is an automatically generated build release.\nPlease obtain the packaged version of this release from the python artifact repo at:\n https://console.cloud.google.com/artifacts/python/glambie-0/europe-west1/pr.\nInstructions on how to install packages from this repo are included in the README.md. Please view CHANGELOG.md for additional details."
+          body: "This is an automatically generated build release.\nPlease obtain the packaged version of this release from the python artifact repo at:\n https://console.cloud.google.com/artifacts/python/glambie/europe-west1/pr.\nInstructions on how to install packages from this repo are included in the README.md. Please view CHANGELOG.md for additional details."
           tag_name: ${{ steps.push_tags.outputs.full_version }}
 
       - name: Deploy to Google Python Artifact Registry
         # note twine is able to upload to gcloud because a keyfile and the keyring backend was installed during image build.
         run: |
           conda activate ${{ inputs.package_name }}
-          twine upload --verbose --repository-url https://europe-west1-python.pkg.dev/glambie-0/pr/ dist/*
+          twine upload --verbose --repository-url https://europe-west1-python.pkg.dev/glambie/pr/ dist/*
 
       - name: Raise Pull Requests in dependent repos
         # This is very similar to Dependabot, and should probably be replaced with it in the future.

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -38,11 +38,11 @@ jobs:
 
       - id: lower_case_ref
         run: |
-          echo "::set-output name=image_name::europe-west1-docker.pkg.dev/glambie-0/dr/${{ inputs.package_name }}_$(echo "$GITHUB_REF_NAME" | awk '{print tolower($0)}')"
+          echo "::set-output name=image_name::europe-west1-docker.pkg.dev/glambie/dr/${{ inputs.package_name }}_$(echo "$GITHUB_REF_NAME" | awk '{print tolower($0)}')"
 
       - id: specify
         run: |
-          echo "::set-output name=image_name::europe-west1-docker.pkg.dev/glambie-0/dr/${{ inputs.package_name }}_$(echo "$GITHUB_REF_NAME" | awk '{print tolower($0)}')"
+          echo "::set-output name=image_name::europe-west1-docker.pkg.dev/glambie/dr/${{ inputs.package_name }}_$(echo "$GITHUB_REF_NAME" | awk '{print tolower($0)}')"
     outputs:
       image_name: ${{ steps.specify.outputs.image_name }}
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ to run `gcloud auth login --no-launch-browser` and follow the simple instruction
 the latest version from the Earthwave Python Google Artifact Repository:
 
 ```
-pip install glambie --extra-index-url https://europe-west1-python.pkg.dev/glambie-0/pr/simple/ --use-deprecated=legacy-resolver
+pip install glambie --extra-index-url https://europe-west1-python.pkg.dev/glambie/pr/simple/ --use-deprecated=legacy-resolver
 ```
 
 You can then use this package as follows (obviously you will need to edit this section after copying this template):
@@ -77,7 +77,7 @@ the latest version from the Earthwave Python Google Artifact Repository:
 Then finally install this package for development:
 
 ```
-pip install -e . --extra-index-url https://europe-west1-python.pkg.dev/glambie-0/pr/simple/ --use-deprecated=legacy-resolver
+pip install -e . --extra-index-url https://europe-west1-python.pkg.dev/glambie/pr/simple/ --use-deprecated=legacy-resolver
 ```
 
 You should now be able to run and pass the unit tests simply by running:


### PR DESCRIPTION
We need to swap out the secrets we use internally at Earthwave for a set of secrets appropriate for the public.

We'll also need to set up separate google artifact repositories, and hugely limit the permissions of the credentials that we "give out" via secrets.

Lastly, we need some careful testing to make absolutely sure the general public can't screw with our servers, but that comes in the next branch, when we try to take this call public.