### PR TITLE
Cumulative vs derivative

### DIFF
--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -8,6 +8,7 @@ from glambie.const.regions import RGIRegion
 import numpy as np
 import pandas as pd
 import warnings
+from glambie.util.timeseries_helpers import derivative_to_cumulative
 
 
 @dataclass
@@ -90,11 +91,10 @@ class TimeseriesData():
             Instead of start_dates and end_dates, the column 'dates' is used
         """
         if not self.is_cumulative_valid():
-            warnings.warn("Cumulative timeseries may be invalid. This may be due to the timeseries containing"
+            warnings.warn("Cumulative timeseries may be invalid. This may be due to the timeseries containing "
                           "gaps or overlapping periods.")
-        dates = np.array([self.start_dates[0], *self.end_dates])
-        changes = np.array([0, *np.array(pd.Series(self.changes.cumsum()))])
-        errors = np.array([0, *self.errors])
+        dates, changes = derivative_to_cumulative(self.start_dates, self.end_dates, self.changes)
+        errors = np.array([0, *self.errors])  # need to handle errors in the future too
         df_cumulative = pd.DataFrame({'dates': dates,
                                       'changes': changes,
                                       'errors': errors,

--- a/glambie/plot/plot_helpers.py
+++ b/glambie/plot/plot_helpers.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+"""
+Handy functions to help making plots
+"""
+
+
+def autoscale_y_axis(ax, margin=0.1):
+    """
+    This function rescales the y-axis based on the data that is visible given the current xlim of the axis.
+    Can be used after changing x-axis to rescale y-axis
+
+    Parameters
+    ----------
+    ax : matplitlib.axes.axes
+        a matplotlib axes object
+    margin : float, optional
+        the fraction of the total height of the y-data to pad the upper and lower ylims, by default 0.1
+    """
+
+    def get_bottom_top(line):
+        xd = line.get_xdata()
+        yd = line.get_ydata()
+        lo, hi = ax.get_xlim()
+        y_displayed = yd[((xd > lo) & (xd < hi))]
+        h = np.max(y_displayed) - np.min(y_displayed)
+        bot = np.min(y_displayed) - margin * h
+        top = np.max(y_displayed) + margin * h
+        return bot, top
+
+    lines = ax.get_lines()
+    bot, top = np.inf, -np.inf
+
+    for line in lines:
+        new_bot, new_top = get_bottom_top(line)
+        if new_bot < bot:
+            bot = new_bot
+        if new_top > top:
+            top = new_top
+
+    ax.set_ylim(bot, top)

--- a/glambie/util/timeseries_helpers.py
+++ b/glambie/util/timeseries_helpers.py
@@ -3,6 +3,7 @@ import numpy as np
 import math
 from scipy import interpolate
 from typing import Union
+import pandas as pd
 
 
 def contains_duplicates(x: np.array) -> bool:
@@ -356,3 +357,71 @@ def combine_timeseries(t_array: list[np.ndarray],
         plt.legend()
         plt.show()
     return t_array_combined, y_array_combined, full_resampled_data
+
+
+def derivative_to_cumulative(start_dates: list[float],
+                             end_dates: list[float],
+                             changes: list[float],
+                             return_type="arrays"):
+    """
+    Calculates a cumulative timeseries from a list of non cumulative changes between start and end date
+
+    Parameters
+    ----------
+    start_dates : np.array or list of decimal dates
+        start dates of each time period
+    end_dates : np.array or list of decimal dates
+        end dates of each time period
+    changes : np.array or list
+        changes between start and end date
+    return_type : str, optional
+        type in which the result is returned. Current options are: 'arrays' and 'dataframe', by default 'arrays'
+
+    Returns
+    -------
+    Union[np.array, np.array] or pd.DataFrame, depending on specified return_type
+        'arrays': (dates, cumulative_changes)
+        'dataframe': pd.DataFrame({'dates': dates, 'changes': changes})
+    """
+    dates = np.array([start_dates[0], *end_dates])
+    changes = np.array([0, *np.array(pd.Series(changes).cumsum())])
+    if return_type == "arrays":
+        return dates, changes
+    elif return_type == "dataframe":
+        df_cumulative = pd.DataFrame({'dates': dates,
+                                      'changes': changes,
+                                      })
+        return df_cumulative
+
+
+def cumulative_to_derivative(dates, cumulative_changes, return_type="arrays"):
+    """
+    Calculates a a list of non cumulative changes between start and end dates from a list of cumulative changes.
+
+    Parameters
+    ----------
+    dates : np.array or list of decimal dates
+        dates of timeseries
+    changes : np.array or list
+        cumulative changes
+    return_type : str, optional
+        type in which the result is returned. Current options are: 'arrays' and 'dataframe', by default 'arrays'
+
+    Returns
+    -------
+    Union[np.array, np.array, np.array] or pd.DataFrame, depending on specified return_type
+        'arrays': (start_dates, end_dates, changes)
+        'dataframe': pd.DataFrame({'start_dates': start_dates, 'end_dates': end_dates, 'changes': changes})
+    """
+    # remove first row
+    derivative = np.array(pd.Series(cumulative_changes).diff().iloc[1:])
+    # remove last row for start dates
+    start_dates = np.array(pd.Series(dates).iloc[:-1])
+    # remove first row for end dates
+    end_dates = np.array(pd.Series(dates).iloc[1:])
+
+    if return_type == "arrays":
+        return start_dates, end_dates, derivative
+    elif return_type == "dataframe":
+        df = pd.DataFrame({"start_dates": start_dates, "end_dates": end_dates, "changes": derivative})
+        return df

--- a/glambie/util/timeseries_helpers.py
+++ b/glambie/util/timeseries_helpers.py
@@ -1,3 +1,4 @@
+import warnings
 from matplotlib import pyplot as plt
 import numpy as np
 import math
@@ -224,10 +225,16 @@ def timeseries_as_months(fractional_year_array: np.array, downsample_to_month: b
     """
     if downsample_to_month:
         t0 = math.floor(np.min(fractional_year_array) * 12) / 12.
-        t1 = math.ceil(np.max(fractional_year_array) * 12 + 1) / 12.
-        monthly_array = np.arange((t1 - t0) * 12) / 12. + t0
+        t1 = math.ceil(np.max(fractional_year_array) * 12) / 12.
+        # small hack to include last element in case it's on a full integer number
+        monthly_array = np.arange(math.ceil((t1 - t0 + 0.00001) * 12)) / 12. + t0
     else:
         monthly_array = np.floor(fractional_year_array * 12) / 12.
+
+    if contains_duplicates(monthly_array):
+        warnings.warn("The rounded dates contain duplicates."
+                      " To avoid this, do not to use the function with data at monthly resolution or higher")
+
     return monthly_array
 
 
@@ -394,7 +401,7 @@ def derivative_to_cumulative(start_dates: list[float],
         return df_cumulative
 
 
-def cumulative_to_derivative(dates, cumulative_changes, return_type="arrays"):
+def cumulative_to_derivative(fractional_year_array, cumulative_changes, return_type="arrays"):
     """
     Calculates a a list of non cumulative changes between start and end dates from a list of cumulative changes.
 
@@ -416,12 +423,41 @@ def cumulative_to_derivative(dates, cumulative_changes, return_type="arrays"):
     # remove first row
     derivative = np.array(pd.Series(cumulative_changes).diff().iloc[1:])
     # remove last row for start dates
-    start_dates = np.array(pd.Series(dates).iloc[:-1])
+    start_dates = np.array(pd.Series(fractional_year_array).iloc[:-1])
     # remove first row for end dates
-    end_dates = np.array(pd.Series(dates).iloc[1:])
+    end_dates = np.array(pd.Series(fractional_year_array).iloc[1:])
 
     if return_type == "arrays":
         return start_dates, end_dates, derivative
     elif return_type == "dataframe":
         df = pd.DataFrame({"start_dates": start_dates, "end_dates": end_dates, "changes": derivative})
         return df
+
+
+def resample_derivative_timeseries_to_monthly_grid(start_dates, end_dates, changes):
+    """
+    Resample a timeseries of derivatives to a uniform monthly grid.
+    The monthly grid is defined by timeseries_as_months(), containing 12 evenly spaced months.
+
+    Parameters
+    ----------
+    start_dates : np.array or list of decimal dates
+        start dates of each time period
+    end_dates : np.array or list of decimal dates
+        end dates of each time period
+    changes : np.array or list
+        changes between start and end date
+
+    Returns
+    -------
+    Union[np.ndarray,np.ndarray,np.ndarray]
+        (start_dates, end_dates, changes) resampled to the monthly grid
+    """
+    # 1 convert to cumulative (to make sure rate is not lost during the resample process)
+    dates, changes = derivative_to_cumulative(start_dates, end_dates, changes)
+    # 2 resample to the monthly grid defined by timeseries_as_months()
+    monthly_grid = timeseries_as_months(dates)
+    changes = resample_1d_array(dates, changes, monthly_grid)
+    # 3 convert back to derivatives
+    start_dates, end_dates, changes = cumulative_to_derivative(monthly_grid, changes, return_type="arrays")
+    return start_dates, end_dates, changes

--- a/glambie/util/timeseries_helpers.py
+++ b/glambie/util/timeseries_helpers.py
@@ -232,8 +232,8 @@ def timeseries_as_months(fractional_year_array: np.array, downsample_to_month: b
         monthly_array = np.floor(fractional_year_array * 12) / 12.
 
     if contains_duplicates(monthly_array):
-        warnings.warn("The rounded dates contain duplicates."
-                      " To avoid this, do not to use the function with data at monthly resolution or higher")
+        warnings.warn("The rounded dates contain duplicates. "
+                      "To avoid this, use the function with data at lower temporal resolution than monthly")
 
     return monthly_array
 

--- a/tests/util/test_timeseries_helpers.py
+++ b/tests/util/test_timeseries_helpers.py
@@ -39,18 +39,18 @@ def test_moving_average_with_clip():
 
 def test_timeseries_as_months():
     # basic test
-    f = np.array([2010, 2011])
-    ts_new = timeseries_as_months(f, downsample_to_month=True)
+    dates = np.array([2010, 2011])
+    ts_new = timeseries_as_months(dates, downsample_to_month=True)
     assert len(ts_new) == 13
     assert ts_new[0] == 2010.0
     assert ts_new[1] == 2010.0 + (1 / 12)
-    #  test input should equal output
-    f = np.array([2010., 2010 + (1 / 12), 2010 + (2 / 12)])
-    ts_new = timeseries_as_months(f, downsample_to_month=True)
-    assert np.array_equal(f, ts_new)
-    #  should pad last element
-    f = np.array([2010.02, 2010.12, 2010.22])
-    ts_new = timeseries_as_months(f, downsample_to_month=True)
+    # test input should equal output
+    dates = np.array([2010., 2010 + (1 / 12), 2010 + (2 / 12)])
+    ts_new = timeseries_as_months(dates, downsample_to_month=True)
+    assert np.array_equal(dates, ts_new)
+    # should pad last element
+    dates = np.array([2010.02, 2010.12, 2010.22])
+    ts_new = timeseries_as_months(dates, downsample_to_month=True)
     assert ts_new[-1] == 2010.25
 
 


### PR DESCRIPTION
1.)  Improved conversion tools from derivatives to cumulative timeseries (and back), added to timeseries_helpers.
This way it can be used independently from TimeseriesData objects.
n.b. might be worth splitting timeseries_helpers.py into multiple files in the future.

2.) Added function to resample a derivative timeseries to an evenly spaced monthly grid

3.) Also random plot helpers added. e.g. in this case to auto-scale y-axis upon manually changing x-axis. 