### PR TITLE
Add units to data catalogue

### DIFF
--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 import os
 
-from matplotlib import units
-
 from glambie.const.data_groups import GLAMBIE_DATA_GROUPS
 from glambie.const.regions import REGIONS
 from glambie.const.regions import RGIRegion

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import os
 
+from matplotlib import units
+
 from glambie.const.data_groups import GLAMBIE_DATA_GROUPS
 from glambie.const.regions import REGIONS
 from glambie.const.regions import RGIRegion
@@ -61,7 +63,9 @@ class DataCatalogue():
             region = REGIONS[ds_dict['region']]
             data_group = GLAMBIE_DATA_GROUPS[ds_dict['data_group']]
             user_group = ds_dict['user_group']
-            datasets.append(Timeseries(data_filepath=fp, region=region, data_group=data_group, user_group=user_group))
+            unit = ds_dict['unit']
+            datasets.append(Timeseries(data_filepath=fp, region=region, data_group=data_group, user_group=user_group,
+                                       unit=unit))
 
         return DataCatalogue(basepath, datasets)
 

--- a/tests/data/test_data_catalogue.py
+++ b/tests/data/test_data_catalogue.py
@@ -12,19 +12,22 @@ def example_catalogue():
             "filename": "iceland_altimetry_sharks.csv",
             "region": "iceland",
             "user_group": "sharks",
-            "data_group": "altimetry"
+            "data_group": "altimetry",
+            "unit": "m"
         },
         {
             "filename": "svalbard_altimetry_sharks.csv",
             "region": "svalbard",
             "user_group": "sharks",
-            "data_group": "altimetry"
+            "data_group": "altimetry",
+            "unit": "m"
         },
         {
             "filename": "svalbard_altimetry_lions.csv",
             "region": "svalbard",
             "user_group": "lions",
-            "data_group": "gravimetry"
+            "data_group": "gravimetry",
+            "unit": "m"
         }]})
 
 
@@ -36,7 +39,8 @@ def example_catalogue_small():
             "filename": "central_asia_demdiff_sharks.csv",
             "region": "central_asia",
             "user_group": "sharks",
-            "data_group": "demdiff"
+            "data_group": "demdiff",
+            "unit": "m"
         }]})
 
 
@@ -54,6 +58,7 @@ def test_data_catalogue_datasets_correctly_ingested(example_catalogue):
     assert example_catalogue.datasets[2].region.name == 'svalbard'
     assert example_catalogue.datasets[1].data_group.name == 'altimetry'
     assert example_catalogue.datasets[2].data_group.name == 'gravimetry'
+    assert example_catalogue.datasets[0].unit == 'm'
 
 
 def test_get_filtered_catalogue_by_region(example_catalogue):

--- a/tests/test_data/datastore/meta.json
+++ b/tests/test_data/datastore/meta.json
@@ -5,21 +5,21 @@
 	    "region": "iceland",
 	    "user_group" : "sharks",
 	    "data_group" : "altimetry",
-		"unit" : "m"
+		"unit" : "meters"
 	  },
 	  {
 	    "filename" : "alaska_altimetry_sharks.csv",
 	    "region": "alaska",
 	    "user_group" : "sharks",
 	    "data_group" : "altimetry",
-		"unit" : "m"
+		"unit" : "meters"
 	  },
 	  {
 	    "filename" : "svalbard_altimetry_sharks.csv",
 	    "region": "svalbard",
 	    "user_group" : "sharks",
 	    "data_group" : "altimetry",
-		"unit" : "m"
+		"unit" : "meters"
 
 	  }, 	  
 	  {
@@ -27,7 +27,7 @@
 	    "region": "svalbard",
 	    "user_group" : "lions",
 	    "data_group" : "altimetry",
-		"unit" : "m"
+		"unit" : "meters"
 	  }
   ]
 }

--- a/tests/test_data/datastore/meta.json
+++ b/tests/test_data/datastore/meta.json
@@ -4,25 +4,30 @@
 	    "filename" : "iceland_altimetry_sharks.csv",
 	    "region": "iceland",
 	    "user_group" : "sharks",
-	    "data_group" : "altimetry"
+	    "data_group" : "altimetry",
+		"unit" : "m"
 	  },
 	  {
 	    "filename" : "alaska_altimetry_sharks.csv",
 	    "region": "alaska",
 	    "user_group" : "sharks",
-	    "data_group" : "altimetry"
+	    "data_group" : "altimetry",
+		"unit" : "m"
 	  },
 	  {
 	    "filename" : "svalbard_altimetry_sharks.csv",
 	    "region": "svalbard",
 	    "user_group" : "sharks",
-	    "data_group" : "altimetry"
+	    "data_group" : "altimetry",
+		"unit" : "m"
+
 	  }, 	  
 	  {
 	    "filename" : "svalbard_altimetry_lions.csv",
 	    "region": "svalbard",
 	    "user_group" : "lions",
-	    "data_group" : "altimetry"
+	    "data_group" : "altimetry",
+		"unit" : "m"
 	  }
   ]
 }


### PR DESCRIPTION
Quick change to take timeseries units that are now specified in the meta data json file, and add them to the data catalogue and timeseries objects.