### PR TITLE
Conversions of timeseries mass units, resampling and temporal homogenization

### DIFF
--- a/glambie/const/constants.py
+++ b/glambie/const/constants.py
@@ -1,7 +1,13 @@
 """
 A set of constants used within the glambie software
 """
+from enum import Enum
 
 DENSITY_OF_WATER_GT_PER_M3 = 997
 DENSITY_OF_ICE_GT_PER_M3 = 850  # Huss et al. (2013)
 OCEAN_AREA_IN_KM2 = 3.625e8  # Cogley et al. (2012)
+
+
+class YearType(Enum):
+    GLACIOLOGICAL = "glaciological"
+    CALENDAR = "calendar"

--- a/glambie/const/constants.py
+++ b/glambie/const/constants.py
@@ -1,0 +1,7 @@
+"""
+A set of constants used within the glambie software
+"""
+
+DENSITY_OF_WATER_GT_PER_M3 = 997
+DENSITY_OF_ICE_GT_PER_M3 = 850  # Huss et al. (2013)
+OCEAN_AREA_IN_KM2 = 3.625e8  # Cogley et al. (2012)

--- a/glambie/const/constants.py
+++ b/glambie/const/constants.py
@@ -3,8 +3,8 @@ A set of constants used within the glambie software
 """
 from enum import Enum
 
-DENSITY_OF_WATER_GT_PER_M3 = 997
-DENSITY_OF_ICE_GT_PER_M3 = 850  # Huss et al. (2013)
+DENSITY_OF_WATER_KG_PER_M3 = 997
+DENSITY_OF_ICE_KG_PER_M3 = 850  # Huss et al. (2013)
 OCEAN_AREA_IN_KM2 = 3.625e8  # Cogley et al. (2012)
 
 

--- a/glambie/const/data_groups.py
+++ b/glambie/const/data_groups.py
@@ -11,7 +11,6 @@ GLAMBIE_DATA_GROUPS = {
     'altimetry': GlambieDataGroup(name='altimetry', long_name='Altimetry'),
     'demdiff': GlambieDataGroup(name='demdiff', long_name='DEM differencing'),
     'gravimetry': GlambieDataGroup(name='gravimetry', long_name='Gravimetry'),
-    # Here, 'Glaciological' refers to measurements of the glacier's surface from seasonal or annual in-situ campaigns.
     'glaciological': GlambieDataGroup(name='glaciological', long_name='Glaciological'),
     'combined': GlambieDataGroup(name='combined', long_name='Combination of methods')
 }

--- a/glambie/const/data_groups.py
+++ b/glambie/const/data_groups.py
@@ -12,5 +12,6 @@ GLAMBIE_DATA_GROUPS = {
     'demdiff': GlambieDataGroup(name='demdiff', long_name='DEM differencing'),
     'gravimetry': GlambieDataGroup(name='gravimetry', long_name='Gravimetry'),
     'glaciological': GlambieDataGroup(name='glaciological', long_name='Glaciological'),
-    'combined': GlambieDataGroup(name='combined', long_name='Combination of methods')
+    'combined': GlambieDataGroup(name='combined', long_name='Combination of methods'),
+    'consensus': GlambieDataGroup(name='consensus', long_name='Consensus of a combination of data sets')
 }

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -53,11 +53,11 @@ class DataCatalogue():
         DataCatalogue
             data catalogue containing the metadata of datasets, the actual timeseries data will lazy loaded
         """
-        basepath = os.path.join(*meta_data_dict['basepath'])
+        base_path = os.path.join(*meta_data_dict['basepath'])
         datasets_dict = meta_data_dict['datasets']
         datasets = []
         for ds_dict in datasets_dict:
-            fp = os.path.join(basepath, ds_dict['filename'])
+            fp = os.path.join(base_path, ds_dict['filename'])
             region = REGIONS[ds_dict['region']]
             data_group = GLAMBIE_DATA_GROUPS[ds_dict['data_group']]
             user_group = ds_dict['user_group']
@@ -65,7 +65,27 @@ class DataCatalogue():
             datasets.append(Timeseries(data_filepath=fp, region=region, data_group=data_group, user_group=user_group,
                                        unit=unit))
 
-        return DataCatalogue(basepath, datasets)
+        return DataCatalogue(base_path, datasets)
+
+    @staticmethod
+    def from_list(datasets_list: list[Timeseries], base_path: str = "") -> DataCatalogue:
+        """
+        Loads a catalogue from a list of Timeseries datasets
+
+        Parameters
+        ----------
+        datasets_list : list
+            list of Timeseries objects
+        basepath : str
+            basepath for loading the actual data, default is an empty string ''
+            Note that if the data is already loaded there is no need to set this parameter.
+
+        Returns
+        -------
+        DataCatalogue
+            data catalogue containing the metadata of datasets
+        """
+        return DataCatalogue(base_path, datasets_list)
 
     @property
     def datasets(self) -> list[Timeseries]:

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -53,7 +53,7 @@ class DataCatalogue():
         DataCatalogue
             data catalogue containing the metadata of datasets, the actual timeseries data will lazy loaded
         """
-        base_path = os.path.join(*meta_data_dict['basepath'])
+        base_path = os.path.join(*meta_data_dict['base_path'])
         datasets_dict = meta_data_dict['datasets']
         datasets = []
         for ds_dict in datasets_dict:
@@ -76,7 +76,7 @@ class DataCatalogue():
         ----------
         datasets_list : list
             list of Timeseries objects
-        basepath : str
+        base_path : str
             basepath for loading the actual data, default is an empty string ''
             Note that if the data is already loaded there is no need to set this parameter.
 

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -140,6 +140,18 @@ class DataCatalogue():
             if not dataset.is_data_loaded:
                 dataset.load_data()
 
+    def datasets_are_same_unit(self):
+        """
+        Checks if all datasets within catalogue have the same unit
+
+        Returns
+        -------
+        bool
+            True if all dataset units are the same, False otherwise
+        """
+        unit = self.datasets[0].unit
+        return all(dataset.unit == unit for dataset in self.datasets)
+
     def __len__(self) -> int:
         return len(self._datasets)
 

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -252,8 +252,8 @@ class Timeseries():
         return all(s % 1 == year_start for s in self.data.start_dates) and all(s % 1 == year_start
                                                                                for s in self.data.end_dates)
 
-    def convert_timeseries_to_unit_mwe(self, density_of_water: float = constants.DENSITY_OF_WATER_GT_PER_M3,
-                                       density_of_ice: float = constants.DENSITY_OF_ICE_GT_PER_M3) -> Timeseries:
+    def convert_timeseries_to_unit_mwe(self, density_of_water: float = constants.DENSITY_OF_WATER_KG_PER_M3,
+                                       density_of_ice: float = constants.DENSITY_OF_ICE_KG_PER_M3) -> Timeseries:
         """
         Converts a Timeseries object to the unit of meters water equivalent.
         Returns a copy of itself with the converted glacier changes.
@@ -261,9 +261,9 @@ class Timeseries():
         Parameters
         ----------
         density_of_water: float, optional
-            The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_GT_PER_M3
+            The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_KG_PER_M3
         density_of_ice : float, optional
-            The density of ice in Gt per m3, by default constants.DENSITY_OF_ICE_GT_PER_M3
+            The density of ice in Gt per m3, by default constants.DENSITY_OF_ICE_KG_PER_M3
 
         Returns
         -------
@@ -290,7 +290,7 @@ class Timeseries():
                     "Conversion to mwe not implemented yet for Timeseries with unit '{}'".format(self.unit))
 
     def convert_timeseries_to_unit_gt(self, include_area_change: bool = True,
-                                      density_of_water: float = constants.DENSITY_OF_WATER_GT_PER_M3,
+                                      density_of_water: float = constants.DENSITY_OF_WATER_KG_PER_M3,
                                       rgi_area_version=6) -> Timeseries:
         """
         Converts a Timeseries object to the unit of Gigatonnes.
@@ -306,7 +306,7 @@ class Timeseries():
             as it just uses the average between start and end date to determine the area change since
             the reference year, by default True
         density_of_water: float, optional
-            The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_GT_PER_M3
+            The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_KG_PER_M3
         rgi_area_version: int, optional
             The version of RGI glacier masks to be used to determine the glacier area within the region,
             Current options are 6 or 7, by default 6

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -393,7 +393,8 @@ class Timeseries():
 
     def convert_timeseries_to_annual_trends(self, year_type="calendar") -> Timeseries:
         """
-        _summary_
+        Converts a timeseries to annual trends. Note that this assumes that the timeseries is already using the annual
+        grid for resolutions >= 1 year and the monthly grid for resolutions <= 1 year.
 
         Parameters
         ----------
@@ -404,12 +405,13 @@ class Timeseries():
         Returns
         -------
         Timeseries
-            _description_
+            A copy of the Timeseries object containing the converted timeseries data to annual trends.
 
         Raises
         ------
         AssertionError
-            Thrown if timeseries is not on monthly grid.
+            Thrown if timeseries is not on monthly grid. 
+            Also thrown for resolutions > 1 year if timeseries is not on annual grid.
         """
         # Check if on monthly grid. if not throw an exception
         if not self.timeseries_is_monthly_grid():
@@ -458,3 +460,4 @@ class Timeseries():
             object_copy.data.changes = np.array(new_changes)
 
         return object_copy  # return copy of itself
+

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -213,6 +213,45 @@ class Timeseries():
                              'unit': self.unit
                              }, index=[0])
 
+    def timeseries_is_monthly_grid(self):
+        """
+        Returns True if all values in the self.data.start_dates and self.data.end_dates are on
+        the monthly grid defined by glambie.util.timeseries_helpers.timeseries_as_months.
+        Also returns Trues if the resolution is not monthly, but all dates are using the monthly grid.
+
+        Returns
+        -------
+        bool
+            True if in monthly grid, False otherwise.
+        """
+        return timeseries_is_monthly_grid(self.data.start_dates) and timeseries_is_monthly_grid(self.data.end_dates)
+
+    def timeseries_is_annual_grid(self, year_type: str = "calendar"):
+        """
+        Returns True if all values in the self.data.start_dates and self.data.end_dates are on
+        the annual grid (e.g. 2010.0 wouls be on annual calendar year grid, 2010.1 would not)
+        Also returns Trues if the resolution is not annual, but all dates are using the annual grid.
+
+        Parameters
+        ----------
+        year_type : str, optional
+            which year to use, options are 'calendar' (January to January) or 'glaciological' (Whatever year
+            is defined for the region), by default "calendar"
+
+        Returns
+        -------
+        bool
+            True if in annual grid, False otherwise.
+        """
+        if year_type == "calendar":
+            year_start = 0
+        elif year_type == "glaciological":
+            year_start = self.region.glaciological_year_start
+        else:
+            raise NotImplementedError("Year type '{}' is not implemented yet.".format(year_type))
+        return all(s % 1 == year_start for s in self.data.start_dates) and all(s % 1 == year_start
+                                                                               for s in self.data.end_dates)
+
     def convert_timeseries_to_unit_mwe(self, density_of_water: float = 997,
                                        density_of_ice: float = 850) -> Timeseries:
         """
@@ -349,15 +388,38 @@ class Timeseries():
                 object_copy.data.changes = changes
         return object_copy  # return copy of itself
 
-    def timeseries_is_monthly_grid(self):
+    def convert_timeseries_to_annual_trends(self, year_type="calendar") -> Timeseries:
         """
-        Returns True if all values in the self.data.start_dates and self.data.end_dates are on
-        the monthly grid defined by glambie.util.timeseries_helpers.timeseries_as_months.
-        Also returns Trues if the resolution is not monthly, but all dates are using the monthly grid.
+        _summary_
+
+        Parameters
+        ----------
+        year_type : str, optional
+            which year to use, options are 'calendar' (January to January) or 'glaciological' (Whatever year 
+            is defined for the region), by default "calendar"
 
         Returns
         -------
-        bool
-            True if in monthly grid, False otherwise.
+        Timeseries
+            _description_
         """
-        return timeseries_is_monthly_grid(self.data.start_dates) and timeseries_is_monthly_grid(self.data.end_dates)
+
+        # Check if on monthly grid. if not throw an error
+
+        # # make a deep copy of itself
+        # object_copy = copy.deepcopy(self)
+        # if not self.timeseries_is_monthly_grid():  # if already in monthly grid there is no need to convert
+        #     # check resolution
+        #     if self.data.max_temporal_resolution >= 0.5:  # resolution above half a year: shift to closest month
+        #         start_dates = timeseries_as_months(self.data.start_dates, downsample_to_month=False)
+        #         end_dates = timeseries_as_months(self.data.end_dates, downsample_to_month=False)
+        #         object_copy.data.start_dates = start_dates
+        #         object_copy.data.end_dates = end_dates
+        #     else:  # resolution below half a year: resample timeseries to monthly grid
+        #         start_dates, end_dates, changes = resample_derivative_timeseries_to_monthly_grid(self.data.start_dates,
+        #                                                                                          self.data.end_dates,
+        #                                                                                          self.data.changes)
+        #         object_copy.data.start_dates = start_dates
+        #         object_copy.data.end_dates = end_dates
+        #         object_copy.data.changes = changes
+        # return object_copy  # return copy of itself

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -327,7 +327,6 @@ class Timeseries():
             glacier_area = self.region.rgi7_area
         else:
             raise NotImplementedError("Version '{}' of RGI is not implemented yet.".format(rgi_area_version))
-            glacier_area = self.region.rgi6_area
 
         object_copy = copy.deepcopy(self)
         object_copy.unit = "gt"

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -262,7 +262,7 @@ class Timeseries():
         density_of_water: float, optional
             The density of water in Gt per m3, by default 997
         rgi_area_version: int, optional
-            The version of RGI glacier masks to be used to determine the glacier area within the region, 
+            The version of RGI glacier masks to be used to determine the glacier area within the region,
             Current options are 6 or 7, by default 6
 
         Returns

--- a/glambie/util/date_helpers.py
+++ b/glambie/util/date_helpers.py
@@ -89,14 +89,14 @@ def get_year_timedelta(year: int) -> timedelta:
     return year_length
 
 
-def get_glaciological_years(glaciological_year_start: float, min_date: float, max_date: float, return_type="arrays"):
+def get_years(desired_year_start: float, min_date: float, max_date: float, return_type="arrays"):
     """
-    Returns start and end dates of glaciological years within a timespan (min_date to max_date).
+    Returns start and end dates of years within a timespan (min_date to max_date).
     Only full years within the min_date - max_date time period are included.
 
     Parameters
     ----------
-    glaciological_year_start : float
+    desired_year_start : float
         a floating point number of when the glaciological year should start (between 0 and 1), e.g. 0.75 for October
     min_date : float
         minimum date to be calculated for, in fractional years
@@ -118,17 +118,17 @@ def get_glaciological_years(glaciological_year_start: float, min_date: float, ma
     for year in years:
         # if glaciological year is closer to the end of the year
         # the glaciological year is starting around the end of the previous year
-        if round(glaciological_year_start) == 1:
-            start_date = year - 1 + glaciological_year_start
-            end_date = year + glaciological_year_start
+        if round(desired_year_start) == 1:
+            start_date = year - 1 + desired_year_start
+            end_date = year + desired_year_start
             if (start_date >= min_date) & (end_date <= max_date):
                 start_dates.append(start_date)
                 end_dates.append(end_date)
         # if glaciological year is closer to the start of the year
         # the glaciological year is starting around start of the current year
-        elif round(glaciological_year_start) == 0:
-            start_date = year + glaciological_year_start
-            end_date = year + 1 + glaciological_year_start
+        elif round(desired_year_start) == 0:
+            start_date = year + desired_year_start
+            end_date = year + 1 + desired_year_start
             if (start_date >= min_date) & (end_date <= max_date):
                 start_dates.append(start_date)
                 end_dates.append(end_date)

--- a/glambie/util/mass_height_conversions.py
+++ b/glambie/util/mass_height_conversions.py
@@ -100,7 +100,7 @@ def meters_water_equivalent_to_gigatonnes(variables: Iterable, area: float, dens
     return [_meters_water_equivalent_to_gigatonnes(i, area, density_of_water) for i in variables]
 
 
-def gigatonnes_to_meters_water_equivalent(variables: Iterable, area: float, density_of_water: float = 997) -> list:
+def gigatonnes_to_meters_water_equivalent(variables: Iterable, area_km: float, density_of_water: float = 997) -> list:
     """Function to convert a list of measurements of ice mass loss in gigatonnes into meters water equivalent.
 
     Parameters
@@ -116,7 +116,7 @@ def gigatonnes_to_meters_water_equivalent(variables: Iterable, area: float, dens
     -------
     A list of measurements in meters water equivalent
     """
-    return [_gigatonnes_to_meters_water_equivalent(i, area, density_of_water) for i in variables]
+    return [_gigatonnes_to_meters_water_equivalent(i, area_km, density_of_water) for i in variables]
 
 
 def gigatonnes_to_sea_level_rise(variables: Iterable, ocean_area: float = 3.625e8) -> list:
@@ -137,7 +137,7 @@ def gigatonnes_to_sea_level_rise(variables: Iterable, ocean_area: float = 3.625e
     return [_gigatonnes_to_sea_level_rise(i, ocean_area) for i in variables]
 
 
-def _meters_to_gigatonnes(variable: float, area: float, density_of_ice: float = 850) -> float:
+def _meters_to_gigatonnes(variable: float, area_km: float, density_of_ice: float = 850) -> float:
     """Function to convert a measurement of surface elevation change in meters into ice mass in gigatonnes
 
     Parameters
@@ -153,7 +153,7 @@ def _meters_to_gigatonnes(variable: float, area: float, density_of_ice: float = 
     ----------
     Input variable converted into gigatonnes
     """
-    return variable * density_of_ice * (area / 1e6)  # 1e6 to convert area from km2 to m2
+    return variable * density_of_ice * (area_km / 1e6)  # 1e6 to convert area from km2 to m2
 
 
 def _gigatonnes_to_meters(variable: float, area: float, density_of_ice: float = 850) -> float:
@@ -215,7 +215,7 @@ def _meters_water_equivalent_to_meters(variable: float, density_of_water: float 
     return (variable * density_of_water) / density_of_ice
 
 
-def _gigatonnes_to_meters_water_equivalent(variable: float, area: float, density_of_water: float = 997) -> float:
+def _gigatonnes_to_meters_water_equivalent(variable: float, area_km2: float, density_of_water: float = 997) -> float:
     """Function to convert a measurement of ice mass loss in gigatonnes into meters water equivalent
 
     Parameters
@@ -231,10 +231,10 @@ def _gigatonnes_to_meters_water_equivalent(variable: float, area: float, density
     -------
     Input variable converted into meters water equivalent
     """
-    return (1e6 * variable) / (area * density_of_water)  # 1e6 to convert area from km2 to m2
+    return (1e6 * variable) / (area_km2 * density_of_water)  # 1e6 to convert area from km2 to m2
 
 
-def _meters_water_equivalent_to_gigatonnes(variable: float, area: float, density_of_water: float = 997) -> float:
+def _meters_water_equivalent_to_gigatonnes(variable: float, area_km2: float, density_of_water: float = 997) -> float:
     """Function to convert a measurement of ice mass loss in meters water equivalent into gigatonnes
 
     Parameters
@@ -250,10 +250,10 @@ def _meters_water_equivalent_to_gigatonnes(variable: float, area: float, density
     -------
     Input variable converted into gigatonnes
     """
-    return variable * density_of_water * (area / 1e6)  # 1e6 to convert area from km2 to m2
+    return variable * density_of_water * (area_km2 / 1e6)  # 1e6 to convert area from km2 to m2
 
 
-def _gigatonnes_to_sea_level_rise(variable: float, ocean_area: float = 3.625e8) -> float:
+def _gigatonnes_to_sea_level_rise(variable: float, ocean_area_km2: float = 3.625e8) -> float:
     """Function to convert a measurement of ice mass loss in gigatonnes into sea level rise (millimeters).
 
     Parameters
@@ -267,4 +267,4 @@ def _gigatonnes_to_sea_level_rise(variable: float, ocean_area: float = 3.625e8) 
     ----------
     Input variable converted into sea level rise (millimeters)
     """
-    return abs(variable / ocean_area) * 1e6  # 1e6 to convert area from km2 to m2
+    return abs(variable / ocean_area_km2) * 1e6  # 1e6 to convert area from km2 to m2

--- a/glambie/util/mass_height_conversions.py
+++ b/glambie/util/mass_height_conversions.py
@@ -1,7 +1,7 @@
 from typing import Iterable
 
 
-def meters_to_gigatonnes(variables: Iterable, area: float, density_of_ice: float = 850) -> list:
+def meters_to_gigatonnes(variables: Iterable, area_km2: float, density_of_ice: float = 850) -> list:
     """Function to convert a list of measurements of surface elevation change in meters into ice mass in gigatonnes,
     using the area of a region and the density of ice.
 
@@ -9,7 +9,7 @@ def meters_to_gigatonnes(variables: Iterable, area: float, density_of_ice: float
     ----------
     variables : Iterable
         A list of measurements in meters
-    area : float
+    area_km2 : float
         The area of a region in km2
     density_of_ice : float, optional
         The density of ice in Gt per m3, by default 850
@@ -18,10 +18,10 @@ def meters_to_gigatonnes(variables: Iterable, area: float, density_of_ice: float
     -------
     A list of measurements in gigatonnes
     """
-    return [_meters_to_gigatonnes(i, area, density_of_ice) for i in variables]
+    return [i * density_of_ice * (area_km2 / 1e6) for i in variables]  # 1e6 to convert area from km2 to m2
 
 
-def gigatonnes_to_meters(variables: Iterable, area: float, density_of_ice: float = 850) -> list:
+def gigatonnes_to_meters(variables: Iterable, area_km2: float, density_of_ice: float = 850) -> list:
     """Function to convert a list of measurements of ice mass in gigatonnes into surface elevation change in meters,
     using the area of a region and the density of ice.
 
@@ -29,7 +29,7 @@ def gigatonnes_to_meters(variables: Iterable, area: float, density_of_ice: float
     ----------
     variables : Iterable
         A list of measurements in gigatonnes
-    area : float
+    area_km2 : float
         The area of the region in km2
     density_of_ice : float, optional
         The density of ice in Gt per m3, by default 850
@@ -38,7 +38,7 @@ def gigatonnes_to_meters(variables: Iterable, area: float, density_of_ice: float
     -------
     A list of measurements in meters
     """
-    return [_gigatonnes_to_meters(i, area, density_of_ice) for i in variables]
+    return [(1e6 * variable) / (area_km2 * density_of_ice) for variable in variables]
 
 
 def meters_to_meters_water_equivalent(variables: Iterable, density_of_water: float = 997,
@@ -58,7 +58,7 @@ def meters_to_meters_water_equivalent(variables: Iterable, density_of_water: flo
     -------
     A list of measurements in meters water equivalent
     """
-    return [_meters_to_meters_water_equivalent(i, density_of_water, density_of_ice) for i in variables]
+    return [(variable / density_of_water) * density_of_ice for variable in variables]
 
 
 def meters_water_equivalent_to_meters(variables: Iterable, density_of_water: float = 997,
@@ -78,17 +78,17 @@ def meters_water_equivalent_to_meters(variables: Iterable, density_of_water: flo
     -------
     A list of measurements in meters
     """
-    return [_meters_water_equivalent_to_meters(i, density_of_water, density_of_ice) for i in variables]
+    return [(variable * density_of_water) / density_of_ice for variable in variables]
 
 
-def meters_water_equivalent_to_gigatonnes(variables: Iterable, area: float, density_of_water: float = 997) -> list:
+def meters_water_equivalent_to_gigatonnes(variables: Iterable, area_km2: float, density_of_water: float = 997) -> list:
     """Function to convert a list of measurements of ice mass loss in meters water equivalent to gigatonnes.
 
     Parameters
     ----------
     variables : Iterable
         A list of measurements in meters water equivalent
-    area : float
+    area_km2 : float
         The area of the region in km2
     density_of_water : float, optional
         The density of water in Gt per m3, by default 997
@@ -97,17 +97,17 @@ def meters_water_equivalent_to_gigatonnes(variables: Iterable, area: float, dens
     -------
     A list of measurements in gigatonnes
     """
-    return [_meters_water_equivalent_to_gigatonnes(i, area, density_of_water) for i in variables]
+    return [i * density_of_water * (area_km2 / 1e6) for i in variables]  # 1e6 to convert area from km2 to m2
 
 
-def gigatonnes_to_meters_water_equivalent(variables: Iterable, area_km: float, density_of_water: float = 997) -> list:
+def gigatonnes_to_meters_water_equivalent(variables: Iterable, area_km2: float, density_of_water: float = 997) -> list:
     """Function to convert a list of measurements of ice mass loss in gigatonnes into meters water equivalent.
 
     Parameters
     ----------
     variables : Iterable
         A list of measurements in gigatonnes
-    area : float
+    area_km2 : float
         The area of the region in km2
     density_of_water : float, optional
         The density of water in Gt per m3, by default 997
@@ -116,10 +116,10 @@ def gigatonnes_to_meters_water_equivalent(variables: Iterable, area_km: float, d
     -------
     A list of measurements in meters water equivalent
     """
-    return [_gigatonnes_to_meters_water_equivalent(i, area_km, density_of_water) for i in variables]
+    return [(1e6 * variable) / (area_km2 * density_of_water) for variable in variables]
 
 
-def gigatonnes_to_sea_level_rise(variables: Iterable, ocean_area: float = 3.625e8) -> list:
+def gigatonnes_to_sea_level_rise(variables: Iterable, ocean_area_km2: float = 3.625e8) -> list:
     """Function to convert a list of measurements of ice mass loss in gigatonnes into sea level rise (millimeters). We
     assume a value for the area of the ocean, and that all measured mass loss contributes to sea level change.
 
@@ -127,144 +127,11 @@ def gigatonnes_to_sea_level_rise(variables: Iterable, ocean_area: float = 3.625e
     ----------
     variables : Iterable
         A List of measurements in gigatonnes
-    ocean_area : float, optional
+    ocean_area_km2 : float, optional
         The assumed area of the ocean in km2, by default 3.625e8
 
     Returns
     -------
     A list of measurements in sea level rise (millimeters)
     """
-    return [_gigatonnes_to_sea_level_rise(i, ocean_area) for i in variables]
-
-
-def _meters_to_gigatonnes(variable: float, area_km: float, density_of_ice: float = 850) -> float:
-    """Function to convert a measurement of surface elevation change in meters into ice mass in gigatonnes
-
-    Parameters
-    ----------
-    variable : float
-        The variable to be converted, with input units of meters
-    area : float
-        The area of the region in km2
-    density_of_ice : float, optional
-        The density of ice in Gt per m3, by default 850
-
-    Returns:
-    ----------
-    Input variable converted into gigatonnes
-    """
-    return variable * density_of_ice * (area_km / 1e6)  # 1e6 to convert area from km2 to m2
-
-
-def _gigatonnes_to_meters(variable: float, area: float, density_of_ice: float = 850) -> float:
-    """Function to convert a measurement of ice mass in gigatonnes into surface elevation change in meters
-
-    Parameters
-    ----------
-    variable : float
-        The variable to be converted, with input units of gigatonnes
-    area : float
-        The area of the region in km2
-    density_of_ice : float, optional
-        The density of ice in Gt per m3, by default 850
-
-    Returns:
-    ----------
-    Input variable converted into meters
-    """
-    return (1e6 * variable) / (area * density_of_ice)  # 1e6 to convert area from km2 to m2
-
-
-def _meters_to_meters_water_equivalent(variable: float, density_of_water: float = 997,
-                                       density_of_ice: float = 850) -> float:
-    """Function to convert a measurement of surface elevation change from meters into meters water equivalent.
-
-    Parameters
-    ----------
-    variable : float
-        The variable to be converted, with input units of meters
-    density_of_water : float, optional
-        The density of water in Gt per m3, by default 997
-    density_of_ice : float, optional
-        The density of ice in Gt per m3, by default 850
-
-    Returns
-    -------
-    Input variable converted into meters water equivalent
-    """
-    return (variable / density_of_water) * density_of_ice
-
-
-def _meters_water_equivalent_to_meters(variable: float, density_of_water: float = 997,
-                                       density_of_ice: float = 850) -> float:
-    """Function to convert a measurement of surface elevation change from meters water equivalent into meters.
-
-    Parameters
-    ----------
-    variable : float
-        The variable to be converted, with input units of mwe
-    density_of_water: float, optional
-        The density of water in Gt per m3, by default 997
-    density_of_ice : float, optional
-        The density of ice in Gt per m3, by default 850
-
-    Returns
-    -------
-    Input variable converted into meters
-    """
-    return (variable * density_of_water) / density_of_ice
-
-
-def _gigatonnes_to_meters_water_equivalent(variable: float, area_km2: float, density_of_water: float = 997) -> float:
-    """Function to convert a measurement of ice mass loss in gigatonnes into meters water equivalent
-
-    Parameters
-    ----------
-    variable : float
-        The variable to be converted, with input units of Gt
-    area : float
-        The area of the region in km2
-    density_of_water : float, optional
-        The density of water in Gt per m3, by default 997
-
-    Returns
-    -------
-    Input variable converted into meters water equivalent
-    """
-    return (1e6 * variable) / (area_km2 * density_of_water)  # 1e6 to convert area from km2 to m2
-
-
-def _meters_water_equivalent_to_gigatonnes(variable: float, area_km2: float, density_of_water: float = 997) -> float:
-    """Function to convert a measurement of ice mass loss in meters water equivalent into gigatonnes
-
-    Parameters
-    ----------
-    variable : float
-        The variable to be converted, with input units of mwe
-    area : float
-        The area of the region in km2
-    density_of_water : float, optional
-        The density of water in Gt per m3, by default 997
-
-    Returns
-    -------
-    Input variable converted into gigatonnes
-    """
-    return variable * density_of_water * (area_km2 / 1e6)  # 1e6 to convert area from km2 to m2
-
-
-def _gigatonnes_to_sea_level_rise(variable: float, ocean_area_km2: float = 3.625e8) -> float:
-    """Function to convert a measurement of ice mass loss in gigatonnes into sea level rise (millimeters).
-
-    Parameters
-    ----------
-    variable : float
-        The variable to be converted, with input units of gigatonnes
-    ocean_area : float, optional
-        The assumed area of the ocean in km2, by default 3.625e8
-
-    Returns
-    ----------
-    Input variable converted into sea level rise (millimeters)
-    """
-    return abs(variable / ocean_area_km2) * 1e6  # 1e6 to convert area from km2 to m2
+    return [abs(variable / ocean_area_km2) * 1e6 for variable in variables]  # 1e6 to convert area from km2 to m2

--- a/glambie/util/mass_height_conversions.py
+++ b/glambie/util/mass_height_conversions.py
@@ -3,7 +3,7 @@ from glambie.const import constants
 
 
 def meters_to_gigatonnes(variables: Iterable, area_km2: float,
-                         density_of_ice: float = constants.DENSITY_OF_ICE_GT_PER_M3) -> list:
+                         density_of_ice: float = constants.DENSITY_OF_ICE_KG_PER_M3) -> list:
     """Function to convert a list of measurements of surface elevation change in meters into ice mass in gigatonnes,
     using the area of a region and the density of ice.
 
@@ -14,7 +14,7 @@ def meters_to_gigatonnes(variables: Iterable, area_km2: float,
     area_km2 : float
         The area of a region in km2
     density_of_ice : float, optional
-        The density of ice in Gt per m3, by default constants.DENSITY_OF_ICE_GT_PER_M3
+        The density of ice in kg per m3, by default constants.DENSITY_OF_ICE_KG_PER_M3
 
     Returns
     -------
@@ -24,7 +24,7 @@ def meters_to_gigatonnes(variables: Iterable, area_km2: float,
 
 
 def gigatonnes_to_meters(variables: Iterable, area_km2: float,
-                         density_of_ice: float = constants.DENSITY_OF_ICE_GT_PER_M3) -> list:
+                         density_of_ice: float = constants.DENSITY_OF_ICE_KG_PER_M3) -> list:
     """Function to convert a list of measurements of ice mass in gigatonnes into surface elevation change in meters,
     using the area of a region and the density of ice.
 
@@ -35,7 +35,7 @@ def gigatonnes_to_meters(variables: Iterable, area_km2: float,
     area_km2 : float
         The area of the region in km2
     density_of_ice : float, optional
-        The density of ice in Gt per m3, by default constants.DENSITY_OF_ICE_GT_PER_M3
+        The density of ice in kg per m3, by default constants.DENSITY_OF_ICE_KG_PER_M3
 
     Returns
     -------
@@ -45,8 +45,8 @@ def gigatonnes_to_meters(variables: Iterable, area_km2: float,
 
 
 def meters_to_meters_water_equivalent(variables: Iterable,
-                                      density_of_water: float = constants.DENSITY_OF_WATER_GT_PER_M3,
-                                      density_of_ice: float = constants.DENSITY_OF_ICE_GT_PER_M3) -> list:
+                                      density_of_water: float = constants.DENSITY_OF_WATER_KG_PER_M3,
+                                      density_of_ice: float = constants.DENSITY_OF_ICE_KG_PER_M3) -> list:
     """Function to convert a list of measurements of surface elevation change in meters into meters water equivalent.
 
     Parameters
@@ -54,9 +54,9 @@ def meters_to_meters_water_equivalent(variables: Iterable,
     variables : Iterable
         A list of measurements in meters
     density_of_water : float, optional
-        The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_GT_PER_M3
+        The density of water in kg per m3, by default constants.DENSITY_OF_WATER_KG_PER_M3
     density_of_ice : float, optional
-        The density of ice in Gt per m3, by default constants.DENSITY_OF_ICE_GT_PER_M3
+        The density of ice in kg per m3, by default constants.DENSITY_OF_ICE_KG_PER_M3
 
     Returns
     -------
@@ -66,8 +66,8 @@ def meters_to_meters_water_equivalent(variables: Iterable,
 
 
 def meters_water_equivalent_to_meters(variables: Iterable,
-                                      density_of_water: float = constants.DENSITY_OF_WATER_GT_PER_M3,
-                                      density_of_ice: float = constants.DENSITY_OF_ICE_GT_PER_M3) -> list:
+                                      density_of_water: float = constants.DENSITY_OF_WATER_KG_PER_M3,
+                                      density_of_ice: float = constants.DENSITY_OF_ICE_KG_PER_M3) -> list:
     """Function to convert a list of measurements of surface elevation change in meters water equivalent into meters.
 
     Parameters
@@ -75,9 +75,9 @@ def meters_water_equivalent_to_meters(variables: Iterable,
     variables : Iterable
         A list of measurements in meters water equivalent
     density_of_water : float, optional
-        The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_GT_PER_M3
+        The density of water in kg per m3, by default constants.DENSITY_OF_WATER_KG_PER_M3
     density_of_ice : float, optional
-        The density of ice in Gt per m3, by default constants.DENSITY_OF_ICE_GT_PER_M3
+        The density of ice in kg per m3, by default constants.DENSITY_OF_ICE_KG_PER_M3
 
     Returns
     -------
@@ -87,7 +87,7 @@ def meters_water_equivalent_to_meters(variables: Iterable,
 
 
 def meters_water_equivalent_to_gigatonnes(variables: Iterable, area_km2: float,
-                                          density_of_water: float = constants.DENSITY_OF_WATER_GT_PER_M3) -> list:
+                                          density_of_water: float = constants.DENSITY_OF_WATER_KG_PER_M3) -> list:
     """Function to convert a list of measurements of ice mass loss in meters water equivalent to gigatonnes.
 
     Parameters
@@ -97,7 +97,7 @@ def meters_water_equivalent_to_gigatonnes(variables: Iterable, area_km2: float,
     area_km2 : float
         The area of the region in km2
     density_of_water : float, optional
-        The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_GT_PER_M3
+        The density of water in kg per m3, by default constants.DENSITY_OF_WATER_KG_PER_M3
 
     Returns
     -------
@@ -107,7 +107,7 @@ def meters_water_equivalent_to_gigatonnes(variables: Iterable, area_km2: float,
 
 
 def gigatonnes_to_meters_water_equivalent(variables: Iterable, area_km2: float,
-                                          density_of_water: float = constants.DENSITY_OF_WATER_GT_PER_M3) -> list:
+                                          density_of_water: float = constants.DENSITY_OF_WATER_KG_PER_M3) -> list:
     """Function to convert a list of measurements of ice mass loss in gigatonnes into meters water equivalent.
 
     Parameters
@@ -117,7 +117,7 @@ def gigatonnes_to_meters_water_equivalent(variables: Iterable, area_km2: float,
     area_km2 : float
         The area of the region in km2
     density_of_water : float, optional
-        The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_GT_PER_M3
+        The density of water in kg per m3, by default constants.DENSITY_OF_WATER_KG_PER_M3
 
     Returns
     -------

--- a/glambie/util/mass_height_conversions.py
+++ b/glambie/util/mass_height_conversions.py
@@ -81,6 +81,25 @@ def meters_water_equivalent_to_meters(variables: Iterable, density_of_water: flo
     return [_meters_water_equivalent_to_meters(i, density_of_water, density_of_ice) for i in variables]
 
 
+def meters_water_equivalent_to_gigatonnes(variables: Iterable, area: float, density_of_water: float = 997) -> list:
+    """Function to convert a list of measurements of ice mass loss in meters water equivalent to gigatonnes.
+
+    Parameters
+    ----------
+    variables : Iterable
+        A list of measurements in meters water equivalent
+    area : float
+        The area of the region in km2
+    density_of_water : float, optional
+        The density of water in Gt per m3, by default 997
+
+    Returns
+    -------
+    A list of measurements in gigatonnes
+    """
+    return [_meters_water_equivalent_to_gigatonnes(i, area, density_of_water) for i in variables]
+
+
 def gigatonnes_to_meters_water_equivalent(variables: Iterable, area: float, density_of_water: float = 997) -> list:
     """Function to convert a list of measurements of ice mass loss in gigatonnes into meters water equivalent.
 
@@ -213,6 +232,25 @@ def _gigatonnes_to_meters_water_equivalent(variable: float, area: float, density
     Input variable converted into meters water equivalent
     """
     return (1e6 * variable) / (area * density_of_water)  # 1e6 to convert area from km2 to m2
+
+
+def _meters_water_equivalent_to_gigatonnes(variable: float, area: float, density_of_water: float = 997) -> float:
+    """Function to convert a measurement of ice mass loss in meters water equivalent into gigatonnes
+
+    Parameters
+    ----------
+    variable : float
+        The variable to be converted, with input units of mwe
+    area : float
+        The area of the region in km2
+    density_of_water : float, optional
+        The density of water in Gt per m3, by default 997
+
+    Returns
+    -------
+    Input variable converted into gigatonnes
+    """
+    return variable * density_of_water * (area / 1e6)  # 1e6 to convert area from km2 to m2
 
 
 def _gigatonnes_to_sea_level_rise(variable: float, ocean_area: float = 3.625e8) -> float:

--- a/glambie/util/mass_height_conversions.py
+++ b/glambie/util/mass_height_conversions.py
@@ -1,7 +1,9 @@
 from typing import Iterable
+from glambie.const import constants
 
 
-def meters_to_gigatonnes(variables: Iterable, area_km2: float, density_of_ice: float = 850) -> list:
+def meters_to_gigatonnes(variables: Iterable, area_km2: float,
+                         density_of_ice: float = constants.DENSITY_OF_ICE_GT_PER_M3) -> list:
     """Function to convert a list of measurements of surface elevation change in meters into ice mass in gigatonnes,
     using the area of a region and the density of ice.
 
@@ -12,7 +14,7 @@ def meters_to_gigatonnes(variables: Iterable, area_km2: float, density_of_ice: f
     area_km2 : float
         The area of a region in km2
     density_of_ice : float, optional
-        The density of ice in Gt per m3, by default 850
+        The density of ice in Gt per m3, by default constants.DENSITY_OF_ICE_GT_PER_M3
 
     Returns
     -------
@@ -21,7 +23,8 @@ def meters_to_gigatonnes(variables: Iterable, area_km2: float, density_of_ice: f
     return [i * density_of_ice * (area_km2 / 1e6) for i in variables]  # 1e6 to convert area from km2 to m2
 
 
-def gigatonnes_to_meters(variables: Iterable, area_km2: float, density_of_ice: float = 850) -> list:
+def gigatonnes_to_meters(variables: Iterable, area_km2: float,
+                         density_of_ice: float = constants.DENSITY_OF_ICE_GT_PER_M3) -> list:
     """Function to convert a list of measurements of ice mass in gigatonnes into surface elevation change in meters,
     using the area of a region and the density of ice.
 
@@ -32,7 +35,7 @@ def gigatonnes_to_meters(variables: Iterable, area_km2: float, density_of_ice: f
     area_km2 : float
         The area of the region in km2
     density_of_ice : float, optional
-        The density of ice in Gt per m3, by default 850
+        The density of ice in Gt per m3, by default constants.DENSITY_OF_ICE_GT_PER_M3
 
     Returns
     -------
@@ -41,8 +44,9 @@ def gigatonnes_to_meters(variables: Iterable, area_km2: float, density_of_ice: f
     return [(1e6 * variable) / (area_km2 * density_of_ice) for variable in variables]
 
 
-def meters_to_meters_water_equivalent(variables: Iterable, density_of_water: float = 997,
-                                      density_of_ice: float = 850) -> list:
+def meters_to_meters_water_equivalent(variables: Iterable,
+                                      density_of_water: float = constants.DENSITY_OF_WATER_GT_PER_M3,
+                                      density_of_ice: float = constants.DENSITY_OF_ICE_GT_PER_M3) -> list:
     """Function to convert a list of measurements of surface elevation change in meters into meters water equivalent.
 
     Parameters
@@ -50,9 +54,9 @@ def meters_to_meters_water_equivalent(variables: Iterable, density_of_water: flo
     variables : Iterable
         A list of measurements in meters
     density_of_water : float, optional
-        The density of water in Gt per m3, by default 997
+        The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_GT_PER_M3
     density_of_ice : float, optional
-        The density of ice in Gt per m3, by default 850
+        The density of ice in Gt per m3, by default constants.DENSITY_OF_ICE_GT_PER_M3
 
     Returns
     -------
@@ -61,8 +65,9 @@ def meters_to_meters_water_equivalent(variables: Iterable, density_of_water: flo
     return [(variable / density_of_water) * density_of_ice for variable in variables]
 
 
-def meters_water_equivalent_to_meters(variables: Iterable, density_of_water: float = 997,
-                                      density_of_ice: float = 850) -> list:
+def meters_water_equivalent_to_meters(variables: Iterable,
+                                      density_of_water: float = constants.DENSITY_OF_WATER_GT_PER_M3,
+                                      density_of_ice: float = constants.DENSITY_OF_ICE_GT_PER_M3) -> list:
     """Function to convert a list of measurements of surface elevation change in meters water equivalent into meters.
 
     Parameters
@@ -70,9 +75,9 @@ def meters_water_equivalent_to_meters(variables: Iterable, density_of_water: flo
     variables : Iterable
         A list of measurements in meters water equivalent
     density_of_water : float, optional
-        The density of water in Gt per m3, by default 997
+        The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_GT_PER_M3
     density_of_ice : float, optional
-        The density of ice in Gt per m3, by default 850
+        The density of ice in Gt per m3, by default constants.DENSITY_OF_ICE_GT_PER_M3
 
     Returns
     -------
@@ -81,7 +86,8 @@ def meters_water_equivalent_to_meters(variables: Iterable, density_of_water: flo
     return [(variable * density_of_water) / density_of_ice for variable in variables]
 
 
-def meters_water_equivalent_to_gigatonnes(variables: Iterable, area_km2: float, density_of_water: float = 997) -> list:
+def meters_water_equivalent_to_gigatonnes(variables: Iterable, area_km2: float,
+                                          density_of_water: float = constants.DENSITY_OF_WATER_GT_PER_M3) -> list:
     """Function to convert a list of measurements of ice mass loss in meters water equivalent to gigatonnes.
 
     Parameters
@@ -91,7 +97,7 @@ def meters_water_equivalent_to_gigatonnes(variables: Iterable, area_km2: float, 
     area_km2 : float
         The area of the region in km2
     density_of_water : float, optional
-        The density of water in Gt per m3, by default 997
+        The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_GT_PER_M3
 
     Returns
     -------
@@ -100,7 +106,8 @@ def meters_water_equivalent_to_gigatonnes(variables: Iterable, area_km2: float, 
     return [i * density_of_water * (area_km2 / 1e6) for i in variables]  # 1e6 to convert area from km2 to m2
 
 
-def gigatonnes_to_meters_water_equivalent(variables: Iterable, area_km2: float, density_of_water: float = 997) -> list:
+def gigatonnes_to_meters_water_equivalent(variables: Iterable, area_km2: float,
+                                          density_of_water: float = constants.DENSITY_OF_WATER_GT_PER_M3) -> list:
     """Function to convert a list of measurements of ice mass loss in gigatonnes into meters water equivalent.
 
     Parameters
@@ -110,7 +117,7 @@ def gigatonnes_to_meters_water_equivalent(variables: Iterable, area_km2: float, 
     area_km2 : float
         The area of the region in km2
     density_of_water : float, optional
-        The density of water in Gt per m3, by default 997
+        The density of water in Gt per m3, by default constants.DENSITY_OF_WATER_GT_PER_M3
 
     Returns
     -------
@@ -119,7 +126,7 @@ def gigatonnes_to_meters_water_equivalent(variables: Iterable, area_km2: float, 
     return [(1e6 * variable) / (area_km2 * density_of_water) for variable in variables]
 
 
-def gigatonnes_to_sea_level_rise(variables: Iterable, ocean_area_km2: float = 3.625e8) -> list:
+def gigatonnes_to_sea_level_rise(variables: Iterable, ocean_area_km2: float = constants.OCEAN_AREA_IN_KM2) -> list:
     """Function to convert a list of measurements of ice mass loss in gigatonnes into sea level rise (millimeters). We
     assume a value for the area of the ocean, and that all measured mass loss contributes to sea level change.
 
@@ -128,7 +135,7 @@ def gigatonnes_to_sea_level_rise(variables: Iterable, ocean_area_km2: float = 3.
     variables : Iterable
         A List of measurements in gigatonnes
     ocean_area_km2 : float, optional
-        The assumed area of the ocean in km2, by default 3.625e8
+        The assumed area of the ocean in km2, by default constants.OCEAN_AREA_IN_KM2
 
     Returns
     -------

--- a/glambie/util/timeseries_helpers.py
+++ b/glambie/util/timeseries_helpers.py
@@ -255,7 +255,7 @@ def timeseries_is_monthly_grid(fractional_year_array: np.array) -> bool:
     """
     monthly_grid = timeseries_as_months(fractional_year_array, downsample_to_month=False)
     try:
-        np.testing.assert_equal(monthly_grid, fractional_year_array)
+        np.testing.assert_almost_equal(monthly_grid, fractional_year_array)
     except AssertionError:
         return False
     return True

--- a/glambie/util/timeseries_helpers.py
+++ b/glambie/util/timeseries_helpers.py
@@ -233,7 +233,7 @@ def timeseries_as_months(fractional_year_array: np.array, downsample_to_month: b
 
     if contains_duplicates(monthly_array):
         warnings.warn("The rounded dates contain duplicates. "
-                      "To avoid this, use the function with data at lower temporal resolution than monthly")
+                      "To avoid this, use the function with data at lower temporal resolution than monthly.")
 
     return monthly_array
 
@@ -253,7 +253,9 @@ def timeseries_is_monthly_grid(fractional_year_array: np.array) -> bool:
     Boolean
         True if input series is on monthly grid, False otherwise
     """
-    monthly_grid = timeseries_as_months(fractional_year_array, downsample_to_month=False)
+    with warnings.catch_warnings():  # ignore warning about duplicates
+        warnings.simplefilter("ignore")
+        monthly_grid = timeseries_as_months(fractional_year_array, downsample_to_month=False)
     try:
         np.testing.assert_almost_equal(monthly_grid, fractional_year_array)
     except AssertionError:

--- a/tests/data/test_data_catalogue.py
+++ b/tests/data/test_data_catalogue.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture()
 def example_catalogue():
-    return DataCatalogue.from_dict({"basepath": ["tests", "test_data", "datastore"],
+    return DataCatalogue.from_dict({"base_path": ["tests", "test_data", "datastore"],
                                     "datasets": [
         {
             "filename": "iceland_altimetry_sharks.csv",
@@ -33,7 +33,7 @@ def example_catalogue():
 
 @pytest.fixture()
 def example_catalogue_small():
-    return DataCatalogue.from_dict({"basepath": ["tests", "test_data", "datastore"],
+    return DataCatalogue.from_dict({"base_path": ["tests", "test_data", "datastore"],
                                     "datasets": [
         {
             "filename": "central_asia_demdiff_sharks.csv",

--- a/tests/data/test_data_catalogue.py
+++ b/tests/data/test_data_catalogue.py
@@ -105,3 +105,12 @@ def test_load_all_data(example_catalogue_small):
     example_catalogue_small.load_all_data()
     # now data should be loaded
     assert example_catalogue_small.datasets[0].is_data_loaded
+
+
+def test_datasets_are_same_unit(example_catalogue):
+    # all test datasets are in m
+    assert example_catalogue.datasets_are_same_unit()
+
+    # change first datasets unit
+    example_catalogue.datasets[0].unit = "gt"
+    assert not example_catalogue.datasets_are_same_unit()

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -1,7 +1,7 @@
 import os
 
 from glambie.const.data_groups import GLAMBIE_DATA_GROUPS
-from glambie.const.regions import REGIONS
+from glambie.const.regions import REGIONS, RGIRegion
 from glambie.data.timeseries import Timeseries
 from glambie.data.timeseries import TimeseriesData
 import numpy as np
@@ -198,3 +198,23 @@ def test_convert_timeseries_to_monthly_grid(example_timeseries_ingested):
     assert np.array_equal(example_timeseries_ingested.data.changes, example_timeseries_converted2.data.changes)
     assert np.array_equal(example_timeseries_converted2.data.start_dates, np.array([2010 + 1 / 12, 2011 + 1 / 12]))
     assert np.array_equal(example_timeseries_converted2.data.end_dates, np.array([2011 + 1 / 12, 2012 + 1 / 12]))
+
+
+def test_timeseries_is_annual_grid(example_timeseries_ingested):
+    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type="calendar")
+    example_timeseries_ingested.data.start_dates = [2010, 2011]
+    example_timeseries_ingested.data.end_dates = [2011, 2012]
+    assert example_timeseries_ingested.timeseries_is_annual_grid(year_type="calendar")
+    example_timeseries_ingested.data.end_dates = [2011, 2012.1]
+    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type="calendar")
+
+
+def test_timeseries_is_annual_grid_glaciological_year(example_timeseries_ingested):
+    example_timeseries_ingested.region = REGIONS["iceland"]
+    example_timeseries_ingested.region.glaciological_year_start = 0.75
+    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type="glaciological")
+    example_timeseries_ingested.data.start_dates = [2010.75, 2011.75]
+    example_timeseries_ingested.data.end_dates = [2011.75, 2012.75]
+    assert example_timeseries_ingested.timeseries_is_annual_grid(year_type="glaciological")
+    example_timeseries_ingested.data.end_dates = [2011.75, 2012.76]
+    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type="glaciological")

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -161,7 +161,7 @@ def test_convert_timeseries_with_area_change_rate(example_timeseries_ingested):
     # setting area change rate to 0, so this should give same result as setting include_area_change=False
     example_timeseries_ingested.region.area_change = 0
     converted_timeseries_ac_0 = example_timeseries_ingested.convert_timeseries_to_unit_gt(include_area_change=True)
-    
+
     # no area change rate and area change rate = 0 should give same result
     assert np.array_equal(converted_timeseries_no_ac.data.changes, converted_timeseries_ac_0.data.changes)
 

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -122,3 +122,19 @@ def test_as_cumulative_timeseries_raises_warning(example_timeseries_ingested):
         # Verify warning has been triggered
         assert len(w) == 1
         assert "invalid" in str(w[-1].message)
+
+
+def test_convert_timeseries_to_unit_mwe(example_timeseries_ingested):
+
+    converted_timeseries = example_timeseries_ingested.convert_timeseries_to_unit_mwe()
+    assert converted_timeseries.unit == "mwe"
+    assert example_timeseries_ingested.unit == "m"
+    assert not np.array_equal(converted_timeseries.data.changes, example_timeseries_ingested.data.changes)
+    expected_converted_changes = example_timeseries_ingested.data.changes / 997 * 850
+    assert np.array_equal(converted_timeseries.data.changes, expected_converted_changes)
+
+
+def test_convert_timeseries_to_unit_mwe_no_conversion_when_already_in_mwe(example_timeseries_ingested):
+    example_timeseries_ingested.unit = "mwe"
+    converted_timeseries = example_timeseries_ingested.convert_timeseries_to_unit_mwe()
+    assert np.array_equal(converted_timeseries.data.changes, example_timeseries_ingested.data.changes)

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -126,12 +126,14 @@ def test_as_cumulative_timeseries_raises_warning(example_timeseries_ingested):
 
 
 def test_convert_timeseries_to_unit_mwe(example_timeseries_ingested):
-
-    converted_timeseries = example_timeseries_ingested.convert_timeseries_to_unit_mwe()
+    density_of_water = 997
+    density_of_ice = 850
+    converted_timeseries = example_timeseries_ingested.convert_timeseries_to_unit_mwe(
+        density_of_water=density_of_water, density_of_ice=density_of_ice)
     assert converted_timeseries.unit == "mwe"
     assert example_timeseries_ingested.unit == "m"
     assert not np.array_equal(converted_timeseries.data.changes, example_timeseries_ingested.data.changes)
-    expected_converted_changes = example_timeseries_ingested.data.changes / 997 * 850
+    expected_converted_changes = example_timeseries_ingested.data.changes / density_of_water * density_of_ice
     assert np.array_equal(converted_timeseries.data.changes, expected_converted_changes)
 
 

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -4,6 +4,7 @@ from glambie.const.data_groups import GLAMBIE_DATA_GROUPS
 from glambie.const.regions import REGIONS
 from glambie.data.timeseries import Timeseries
 from glambie.data.timeseries import TimeseriesData
+from glambie.const import constants
 import numpy as np
 import pytest
 import pandas as pd
@@ -238,10 +239,10 @@ def test_convert_timeseries_to_annual_trends_down_sampling_glaciological_year(ex
     example_timeseries_ingested.data.start_dates = np.linspace(2010.75, 2011.75, 13)[:-1]
     example_timeseries_ingested.data.end_dates = np.linspace(2010.75, 2011.75, 13)[1:]
     example_timeseries_ingested.data.changes = np.linspace(1, 11, 12)
-    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type="glaciological")
+    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type=constants.YearType.GLACIOLOGICAL)
     example_timeseries_converted = example_timeseries_ingested.convert_timeseries_to_annual_trends(
-        year_type="glaciological")
-    assert example_timeseries_converted.timeseries_is_annual_grid(year_type="glaciological")
+        year_type=constants.YearType.GLACIOLOGICAL)
+    assert example_timeseries_converted.timeseries_is_annual_grid(year_type=constants.YearType.GLACIOLOGICAL)
     assert len(example_timeseries_converted.data.changes) == 1
     assert example_timeseries_converted.data.changes[0] == example_timeseries_ingested.data.changes.sum()
 
@@ -280,33 +281,33 @@ def test_convert_timeseries_to_annual_trends_up_annual_should_return_same_as_inp
     example_timeseries_ingested.data.start_dates = np.linspace(2010.75, 2015.75, 6)
     example_timeseries_ingested.data.end_dates = np.linspace(2011.75, 2016.75, 6)
     example_timeseries_ingested.data.changes = np.linspace(1, 6, 6)
-    assert example_timeseries_ingested.timeseries_is_annual_grid(year_type="glaciological")
+    assert example_timeseries_ingested.timeseries_is_annual_grid(year_type=constants.YearType.GLACIOLOGICAL)
     example_timeseries_converted = example_timeseries_ingested \
-        .convert_timeseries_to_annual_trends(year_type="glaciological")
-    assert example_timeseries_converted.timeseries_is_annual_grid(year_type="glaciological")
+        .convert_timeseries_to_annual_trends(year_type=constants.YearType.GLACIOLOGICAL)
+    assert example_timeseries_converted.timeseries_is_annual_grid(year_type=constants.YearType.GLACIOLOGICAL)
     assert np.array_equal(example_timeseries_converted.data.start_dates, example_timeseries_ingested.data.start_dates)
     assert np.array_equal(example_timeseries_converted.data.end_dates, example_timeseries_ingested.data.end_dates)
     assert np.array_equal(example_timeseries_converted.data.changes, example_timeseries_ingested.data.changes)
 
 
 def test_timeseries_is_annual_grid(example_timeseries_ingested):
-    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type="calendar")
+    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type=constants.YearType.CALENDAR)
     example_timeseries_ingested.data.start_dates = [2010, 2011]
     example_timeseries_ingested.data.end_dates = [2011, 2012]
-    assert example_timeseries_ingested.timeseries_is_annual_grid(year_type="calendar")
+    assert example_timeseries_ingested.timeseries_is_annual_grid(year_type=constants.YearType.CALENDAR)
     example_timeseries_ingested.data.end_dates = [2011, 2012.1]
-    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type="calendar")
+    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type=constants.YearType.CALENDAR)
 
 
 def test_timeseries_is_annual_grid_glaciological_year(example_timeseries_ingested):
     example_timeseries_ingested.region = REGIONS["iceland"]
     example_timeseries_ingested.region.glaciological_year_start = 0.75
-    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type="glaciological")
+    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type=constants.YearType.GLACIOLOGICAL)
     example_timeseries_ingested.data.start_dates = [2010.75, 2011.75]
     example_timeseries_ingested.data.end_dates = [2011.75, 2012.75]
-    assert example_timeseries_ingested.timeseries_is_annual_grid(year_type="glaciological")
+    assert example_timeseries_ingested.timeseries_is_annual_grid(year_type=constants.YearType.GLACIOLOGICAL)
     example_timeseries_ingested.data.end_dates = [2011.75, 2012.76]
-    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type="glaciological")
+    assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type=constants.YearType.GLACIOLOGICAL)
 
 
 def test_convert_timeseries_to_longterm_trend(example_timeseries_ingested):

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -305,3 +305,14 @@ def test_timeseries_is_annual_grid_glaciological_year(example_timeseries_ingeste
     assert example_timeseries_ingested.timeseries_is_annual_grid(year_type="glaciological")
     example_timeseries_ingested.data.end_dates = [2011.75, 2012.76]
     assert not example_timeseries_ingested.timeseries_is_annual_grid(year_type="glaciological")
+
+
+def test_convert_timeseries_to_longterm_trend(example_timeseries_ingested):
+    example_timeseries_converted = example_timeseries_ingested.convert_timeseries_to_longterm_trend()
+    assert len(example_timeseries_converted.data.changes) == 1
+    assert np.array_equal(example_timeseries_converted.data.changes,
+                          np.array([example_timeseries_ingested.data.changes.sum()]))
+    assert np.array_equal(example_timeseries_converted.data.start_dates,
+                          np.array([example_timeseries_ingested.data.start_dates[0]]))
+    assert np.array_equal(example_timeseries_converted.data.end_dates,
+                          np.array([example_timeseries_ingested.data.end_dates[1]]))

--- a/tests/test_data/datastore/meta.json
+++ b/tests/test_data/datastore/meta.json
@@ -1,4 +1,4 @@
-{  "basepath" : ["tests", "test_data", "datastore"],
+{  "base_path" : ["tests", "test_data", "datastore"],
    "datasets": [
 	  {
 	    "filename" : "iceland_altimetry_sharks.csv",

--- a/tests/util/test_date_helpers.py
+++ b/tests/util/test_date_helpers.py
@@ -1,6 +1,6 @@
 import datetime
 
-from glambie.util.date_helpers import datetime2year, get_glaciological_years
+from glambie.util.date_helpers import datetime2year, get_years
 from glambie.util.date_helpers import datetime_dates_to_fractional_years
 from glambie.util.date_helpers import fractional_years_to_datetime_dates
 from glambie.util.date_helpers import get_year_timedelta
@@ -47,7 +47,7 @@ def test_get_glaciological_years():
     min_date = 2009.5
     max_date = 2010.8
     glaciological_year = 0.75
-    start_dates, end_dates = get_glaciological_years(glaciological_year, min_date=min_date,
+    start_dates, end_dates = get_years(glaciological_year, min_date=min_date,
                                                      max_date=max_date, return_type="arrays")
 
     assert start_dates[0] == 2009 + 0.75
@@ -59,7 +59,7 @@ def test_get_glaciological_years_southern_hemisphere():
     min_date = 2009.7
     max_date = 2015.8
     glaciological_year = 0.25
-    start_dates, end_dates = get_glaciological_years(glaciological_year, min_date=min_date,
+    start_dates, end_dates = get_years(glaciological_year, min_date=min_date,
                                                      max_date=max_date, return_type="arrays")
 
     assert start_dates[0] == 2010 + 0.25

--- a/tests/util/test_date_helpers.py
+++ b/tests/util/test_date_helpers.py
@@ -48,7 +48,7 @@ def test_get_glaciological_years():
     max_date = 2010.8
     glaciological_year = 0.75
     start_dates, end_dates = get_years(glaciological_year, min_date=min_date,
-                                                     max_date=max_date, return_type="arrays")
+                                       max_date=max_date, return_type="arrays")
 
     assert start_dates[0] == 2009 + 0.75
     assert end_dates[0] == 2010 + 0.75
@@ -60,7 +60,7 @@ def test_get_glaciological_years_southern_hemisphere():
     max_date = 2015.8
     glaciological_year = 0.25
     start_dates, end_dates = get_years(glaciological_year, min_date=min_date,
-                                                     max_date=max_date, return_type="arrays")
+                                       max_date=max_date, return_type="arrays")
 
     assert start_dates[0] == 2010 + 0.25
     assert end_dates[0] == 2011 + 0.25

--- a/tests/util/test_mass_height_conversions.py
+++ b/tests/util/test_mass_height_conversions.py
@@ -75,8 +75,8 @@ def test_mwe2gt():
 
     # circular test: should give same as first converting to meters and then to Gt
     m = _meters_water_equivalent_to_meters(mwe)
-    gt = _meters_to_gigatonnes(m, area=area)
-    assert _meters_water_equivalent_to_gigatonnes(mwe, area=area) == gt
+    gt = _meters_to_gigatonnes(m, area_km=area)
+    assert _meters_water_equivalent_to_gigatonnes(mwe, area_km2=area) == gt
 
 
 def test_gigatonnes2slr():
@@ -85,7 +85,7 @@ def test_gigatonnes2slr():
     # if non-default ocean area is used
     test_ocean_area = 3.8e8
     assert _gigatonnes_to_sea_level_rise(test_variable_in_gt,
-                                         ocean_area=test_ocean_area) == abs(50 / 3.8e8) * 1e6
+                                         ocean_area_km2=test_ocean_area) == abs(50 / 3.8e8) * 1e6
 
 
 def test_meters_to_gigatonnes():

--- a/tests/util/test_mass_height_conversions.py
+++ b/tests/util/test_mass_height_conversions.py
@@ -1,11 +1,3 @@
-from glambie.util.mass_height_conversions import _meters_to_gigatonnes
-from glambie.util.mass_height_conversions import _gigatonnes_to_meters
-from glambie.util.mass_height_conversions import _meters_to_meters_water_equivalent
-from glambie.util.mass_height_conversions import _meters_water_equivalent_to_meters
-from glambie.util.mass_height_conversions import _gigatonnes_to_sea_level_rise
-from glambie.util.mass_height_conversions import _gigatonnes_to_meters_water_equivalent
-from glambie.util.mass_height_conversions import _meters_water_equivalent_to_gigatonnes
-
 from glambie.util.mass_height_conversions import meters_to_gigatonnes
 from glambie.util.mass_height_conversions import gigatonnes_to_meters
 from glambie.util.mass_height_conversions import meters_to_meters_water_equivalent
@@ -13,79 +5,6 @@ from glambie.util.mass_height_conversions import meters_water_equivalent_to_mete
 from glambie.util.mass_height_conversions import gigatonnes_to_sea_level_rise
 from glambie.util.mass_height_conversions import gigatonnes_to_meters_water_equivalent
 from glambie.util.mass_height_conversions import meters_water_equivalent_to_gigatonnes
-
-
-def test_meters2gigatonnes():
-    test_variable_in_m = 20
-    test_rgi_area_km2 = 1000
-    assert _meters_to_gigatonnes(20, 1000) == 17
-    # if non-default ice density is used
-    test_density_of_ice_in_gt_per_m3 = 800
-    assert _meters_to_gigatonnes(test_variable_in_m, test_rgi_area_km2, test_density_of_ice_in_gt_per_m3) == 16
-
-
-def test_gigatonnes2meters():
-    test_variable_in_gt = 17
-    test_rgi_area_km2 = 1000
-    assert _gigatonnes_to_meters(test_variable_in_gt, test_rgi_area_km2) == 20
-    # if non-default ice density is used
-    test_density_of_ice_in_gt_per_m3 = 800
-    assert _gigatonnes_to_meters(test_variable_in_gt, test_rgi_area_km2,
-                                 test_density_of_ice_in_gt_per_m3) == 21.25
-
-
-def test_meters2mwe():
-    test_variable_in_m = 20
-    assert _meters_to_meters_water_equivalent(test_variable_in_m) == (20 / 997) * 850
-    # if non-default ice density is used
-    test_density_of_ice = 800
-    assert _meters_to_meters_water_equivalent(test_variable_in_m,
-                                              density_of_ice=test_density_of_ice) == (20 / 997) * 800
-    # if non-default water density is used
-    test_density_of_water = 950
-    assert _meters_to_meters_water_equivalent(test_variable_in_m,
-                                              density_of_water=test_density_of_water) == (20 / 950) * 850
-
-
-def test_mwe2meters():
-    test_variable_in_mwe = 20
-    assert _meters_water_equivalent_to_meters(test_variable_in_mwe) == (20 * 997) / 850
-    # if non-default ice density is used
-    test_density_of_ice = 800
-    assert _meters_water_equivalent_to_meters(test_variable_in_mwe,
-                                              density_of_ice=test_density_of_ice) == (20 * 997) / 800
-    # if non-default water density is used
-    test_density_of_water = 950
-    assert _meters_water_equivalent_to_meters(test_variable_in_mwe,
-                                              density_of_water=test_density_of_water) == (20 * 950) / 850
-
-
-def test_gigatonnes2mwe():
-    test_variable_in_gt = 50
-    test_area = 1000
-    assert _gigatonnes_to_meters_water_equivalent(test_variable_in_gt, test_area) == (1e6 * 50) / (1000 * 997)
-    test_density_of_water = 950
-    assert _gigatonnes_to_meters_water_equivalent(
-        test_variable_in_gt, test_area, density_of_water=test_density_of_water) == (1e6 * 50) / (1000 * 950)
-
-
-def test_mwe2gt():
-    area = 10
-    mwe = 0.2
-
-    # circular test: should give same as first converting to meters and then to Gt
-    m = _meters_water_equivalent_to_meters(mwe)
-    gt = _meters_to_gigatonnes(m, area_km=area)
-    assert _meters_water_equivalent_to_gigatonnes(mwe, area_km2=area) == gt
-
-
-def test_gigatonnes2slr():
-    test_variable_in_gt = 50
-    assert _gigatonnes_to_sea_level_rise(test_variable_in_gt) == abs(50 / 3.625e8) * 1e6
-    # if non-default ocean area is used
-    test_ocean_area = 3.8e8
-    assert _gigatonnes_to_sea_level_rise(test_variable_in_gt,
-                                         ocean_area_km2=test_ocean_area) == abs(50 / 3.8e8) * 1e6
 
 
 def test_meters_to_gigatonnes():
@@ -125,5 +44,5 @@ def test_meters_water_equivalent_to_gigatonnes():
 
     # circular test: should give same as first converting to meters and then to Gt
     m = meters_water_equivalent_to_meters(mwe)
-    gt = meters_to_gigatonnes(m, area=area)
-    assert meters_water_equivalent_to_gigatonnes(mwe, area=area) == gt
+    gt = meters_to_gigatonnes(m, area_km2=area)
+    assert meters_water_equivalent_to_gigatonnes(mwe, area_km2=area) == gt

--- a/tests/util/test_mass_height_conversions.py
+++ b/tests/util/test_mass_height_conversions.py
@@ -4,6 +4,7 @@ from glambie.util.mass_height_conversions import _meters_to_meters_water_equival
 from glambie.util.mass_height_conversions import _meters_water_equivalent_to_meters
 from glambie.util.mass_height_conversions import _gigatonnes_to_sea_level_rise
 from glambie.util.mass_height_conversions import _gigatonnes_to_meters_water_equivalent
+from glambie.util.mass_height_conversions import _meters_water_equivalent_to_gigatonnes
 
 from glambie.util.mass_height_conversions import meters_to_gigatonnes
 from glambie.util.mass_height_conversions import gigatonnes_to_meters
@@ -11,6 +12,7 @@ from glambie.util.mass_height_conversions import meters_to_meters_water_equivale
 from glambie.util.mass_height_conversions import meters_water_equivalent_to_meters
 from glambie.util.mass_height_conversions import gigatonnes_to_sea_level_rise
 from glambie.util.mass_height_conversions import gigatonnes_to_meters_water_equivalent
+from glambie.util.mass_height_conversions import meters_water_equivalent_to_gigatonnes
 
 
 def test_meters2gigatonnes():
@@ -67,6 +69,16 @@ def test_gigatonnes2mwe():
         test_variable_in_gt, test_area, density_of_water=test_density_of_water) == (1e6 * 50) / (1000 * 950)
 
 
+def test_mwe2gt():
+    area = 10
+    mwe = 0.2
+
+    # circular test: should give same as first converting to meters and then to Gt
+    m = _meters_water_equivalent_to_meters(mwe)
+    gt = _meters_to_gigatonnes(m, area=area)
+    assert _meters_water_equivalent_to_gigatonnes(mwe, area=area) == gt
+
+
 def test_gigatonnes2slr():
     test_variable_in_gt = 50
     assert _gigatonnes_to_sea_level_rise(test_variable_in_gt) == abs(50 / 3.625e8) * 1e6
@@ -105,3 +117,13 @@ def test_gigatonnes_to_meters_water_equivalent():
 def test_gigatonnes_to_sea_level_rise():
     gigatonnes_list = [50, 60]
     assert gigatonnes_to_sea_level_rise(gigatonnes_list) == [abs(50 / 3.625e8) * 1e6, abs(60 / 3.625e8) * 1e6]
+
+
+def test_meters_water_equivalent_to_gigatonnes():
+    area = 10
+    mwe = [0.2, 0.4, 0.6, 0.006]
+
+    # circular test: should give same as first converting to meters and then to Gt
+    m = meters_water_equivalent_to_meters(mwe)
+    gt = meters_to_gigatonnes(m, area=area)
+    assert meters_water_equivalent_to_gigatonnes(mwe, area=area) == gt

--- a/tests/util/test_mass_height_conversions.py
+++ b/tests/util/test_mass_height_conversions.py
@@ -5,37 +5,52 @@ from glambie.util.mass_height_conversions import meters_water_equivalent_to_mete
 from glambie.util.mass_height_conversions import gigatonnes_to_sea_level_rise
 from glambie.util.mass_height_conversions import gigatonnes_to_meters_water_equivalent
 from glambie.util.mass_height_conversions import meters_water_equivalent_to_gigatonnes
+from glambie.const import constants
 
 
 def test_meters_to_gigatonnes():
     meters_list = [20, 30]
-    assert meters_to_gigatonnes(meters_list, 1000) == [17, 25.5]
+    assert meters_to_gigatonnes(meters_list, 1000, density_of_ice=850) == [17, 25.5]
 
 
 def test_gigatonnes_to_meters():
     gigatonnes_list = [17, 25.5]
-    assert gigatonnes_to_meters(gigatonnes_list, 1000) == [20, 30]
+    assert gigatonnes_to_meters(gigatonnes_list, 1000, density_of_ice=850) == [20, 30]
 
 
 def test_meters_to_meters_water_equivalent():
     meters_list = [20, 30]
-    assert meters_to_meters_water_equivalent(meters_list) == [(20 / 997) * 850, (30 / 997) * 850]
+    density_of_ice = 852
+    density_of_water = 998
+    assert meters_to_meters_water_equivalent(meters_list, density_of_ice=density_of_ice,
+                                             density_of_water=density_of_water) == [
+        (20 / density_of_water) * density_of_ice, (30 / density_of_water) * density_of_ice]
 
 
 def test_meters_water_equivalent_to_meters():
     mwe_list = [20, 30]
-    assert meters_water_equivalent_to_meters(mwe_list) == [(20 * 997) / 850, (30 * 997) / 850]
+    density_of_ice = 852
+    density_of_water = 998
+    assert meters_water_equivalent_to_meters(mwe_list, density_of_ice=density_of_ice,
+                                             density_of_water=density_of_water) == [
+        (20 * density_of_water) / density_of_ice, (30 * density_of_water) / density_of_ice]
 
 
 def test_gigatonnes_to_meters_water_equivalent():
     gigatonnes_list = [50, 60]
-    assert gigatonnes_to_meters_water_equivalent(gigatonnes_list,
-                                                 1000) == [(1e6 * 50) / (1000 * 997), (1e6 * 60) / (1000 * 997)]
+    density_of_water = 1006
+    assert gigatonnes_to_meters_water_equivalent(gigatonnes_list, 1000, density_of_water=density_of_water) == [
+        (1e6 * 50) / (1000 * density_of_water), (1e6 * 60) / (1000 * density_of_water)]
 
 
 def test_gigatonnes_to_sea_level_rise():
     gigatonnes_list = [50, 60]
-    assert gigatonnes_to_sea_level_rise(gigatonnes_list) == [abs(50 / 3.625e8) * 1e6, abs(60 / 3.625e8) * 1e6]
+    area_ocean = 3.125e8
+    assert gigatonnes_to_sea_level_rise(gigatonnes_list, ocean_area_km2=area_ocean) == [abs(
+        50 / area_ocean) * 1e6, abs(60 / area_ocean) * 1e6]
+    # now test with default parameter
+    assert gigatonnes_to_sea_level_rise(gigatonnes_list) == [abs(
+        50 / constants.OCEAN_AREA_IN_KM2) * 1e6, abs(60 / constants.OCEAN_AREA_IN_KM2) * 1e6]
 
 
 def test_meters_water_equivalent_to_gigatonnes():

--- a/tests/util/test_timeseries_combination_helpers.py
+++ b/tests/util/test_timeseries_combination_helpers.py
@@ -88,6 +88,18 @@ def test_combine_calibrated_timeseries(example_calibrated_series, example_distan
     assert abs(1.0 - calibrated_mean_series[0]) < abs(2.0 - calibrated_mean_series[1])
 
 
+def test_combine_calibrated_timeseries_p_value_0(example_calibrated_series, example_distance_matrix):
+    p_value = 0
+    calibrated_series = combine_calibrated_timeseries(
+        example_calibrated_series, example_distance_matrix, p_value=p_value)
+    assert np.array_equal(np.array([1., 2., 3.66666667, 2.66666667, 1.66666667]), calibrated_series)
+    #  essentially a really high p-value should give the same result as p=0, when floating points don't matter anymore
+    p_value = 100000000000000
+    calibrated_series2 = combine_calibrated_timeseries(
+        example_calibrated_series, example_distance_matrix, p_value=p_value)
+    assert np.array_equal(calibrated_series2, calibrated_series)
+
+
 def test_combine_calibrated_timeseries_high_p_value(example_calibrated_series, example_distance_matrix):
     # when setting a high p-value the weighting matrix will be 0 everywhere outside the covered time period
     p_value = 200000


### PR DESCRIPTION
Added some functionality to convert timeseries objects:

+ to different units (Gt and mwe), also including things such as change in area for example which is defined in the constants for each region.
+ to return an annual timeseries from higher and lower resolution timeseries
+ to return a longterm trend timeseries from higher resolution timeseries
+ a seasonally homogenized timeseries using a higher resolution calibration dataset

Now a Timeseries object can newly return a copy of itself with the converted changes. This is the design envisaged for any changes during the algorithm to each of the datasets. The idea behind that is that during the algorithm the actual data within a Timeseries object will not be edited, but we can return an edited new object. In this way we can compare/use the initial data at any point within the algorithm. Does this make sense?

Note that uncertainties are note implemented yet for this conversion, as the equation for it is not defined yet.