### PR TITLE
fix a typo in the deploy step

### DIFF
--- a/.github/workflows/generic_deploy.yml
+++ b/.github/workflows/generic_deploy.yml
@@ -83,6 +83,9 @@ jobs:
         shell: bash -leo pipefail {0}
     steps:
       - uses: actions/checkout@v3
+        # we need to use the EARTHWAVE ADMIN PAT so that we have permission to push tags.
+        with:
+          token: ${{ secrets.EARTHWAVE_ADMIN_PAT }}      
 
       - name: Prepare repository for interaction
         # we have to manually set the username and email before we can commit and push


### PR DESCRIPTION
A step within Glambie's deployment needs more permissions than it currently has in order to work.