### PR TITLE
Handle large gaps in timeseries

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ will be automatically deleted.
 Note that for security reasons related to Earthwave's servers, only approved contributors may push to this repository.
 If you wish to make a contribution but find that you are unable to push, please email livia@earthwave.co.uk in order to request access.
 
-## Running GLaMBIE
+## Running GlaMBIE
 
 After completing the Installation instructions above, you can use this package as follows:
 ```

--- a/glambie/const/data_groups.py
+++ b/glambie/const/data_groups.py
@@ -16,6 +16,6 @@ GLAMBIE_DATA_GROUPS = {
     'glaciological': GlambieDataGroup(name='glaciological', long_name='Glaciological'),
     'combined': GlambieDataGroup(name='combined', long_name='Combination of methods'),
     'demdiff_and_glaciological': GlambieDataGroup(name='demdiff_and_glaciological',
-                                                  long_name='Demdiff and Glaciological combined'),
+                                                  long_name='Demdiff and Glaciological'),
     'consensus': GlambieDataGroup(name='consensus', long_name='Consensus of a combination of data sets')
 }

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -372,7 +372,7 @@ class Timeseries():
                 # area_unc is calculated as a % of the total area. % can be defined individually per region.
                 area_unc = glacier_area * self.region.area_uncertainty_percentage
                 errors_area_unc_removed = (  # inverting the formula from glambie ATBD
-                    object_copy.data.changes * (
+                    object_copy.data.changes * np.abs(
                         object_copy.data.errors**2 * glacier_area**2
                         - np.abs(object_copy.data.changes)**2 * area_unc**2)**0.5) / (
                             np.abs(object_copy.data.changes) * glacier_area)

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -124,7 +124,8 @@ class TimeseriesData():
             warnings.warn("Cumulative timeseries may be invalid. This may be due to the timeseries containing "
                           "gaps or overlapping periods.")
         dates, changes = derivative_to_cumulative(self.start_dates, self.end_dates, self.changes)
-        errors = np.array([0, *self.errors])  # need to handle errors in the future too
+        _, errors = derivative_to_cumulative(self.start_dates, self.end_dates, self.errors, calculate_as_errors=True)
+
         df_cumulative = pd.DataFrame({'dates': dates,
                                       'changes': changes,
                                       'errors': errors

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -515,6 +515,36 @@ class Timeseries():
         object_copy.area_change_applied = apply_change  # store if has been applied or not
         return object_copy
 
+    def reduce_to_date_window(self, start_date: float, end_date: float) -> Timeseries:
+        """
+        Filter timeseries by start and end date
+
+        Parameters
+        ----------
+        start_date : float
+            decimal year of start date
+        end_date : float
+            decimal year of end date
+
+        Returns
+        -------
+        Timeseries
+            copy of timeseries object with reduced data to desired time window
+        """
+        object_copy = self.copy()
+        df = object_copy.data.as_dataframe()
+        df = df[((df.end_dates <= end_date) & (df.start_dates >= start_date))].reset_index(drop=True)
+        object_copy.data = TimeseriesData(start_dates=np.array(df["start_dates"]),
+                                          end_dates=np.array(df["end_dates"]),
+                                          changes=np.array(df["changes"]),
+                                          errors=np.array(df["errors"]),
+                                          glacier_area_observed=None,
+                                          glacier_area_reference=None,
+                                          hydrological_correction_value=None,
+                                          remarks=None)
+
+        return object_copy
+
     def convert_timeseries_to_monthly_grid(self) -> Timeseries:
         """
         Converts a Timeseries object to follow the monthly grid. Two different approaches are used depending on

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -343,7 +343,7 @@ class Timeseries():
         else:
             object_copy = self.copy()
             object_copy.unit = "mwe"
-            if self.unit == "m":
+            if str.lower(self.unit) == "m":
                 object_copy.data.changes = np.array(meters_to_meters_water_equivalent(object_copy.data.changes,
                                                                                       density_of_water=density_of_water,
                                                                                       density_of_ice=density_of_ice))
@@ -359,7 +359,7 @@ class Timeseries():
                 errors_mwe = df.changes.abs() * ((df.errors / df.changes)**2 + (density_unc / density_of_ice)**2)**0.5
                 object_copy.data.errors = np.array(errors_mwe)
                 return object_copy
-            elif self.unit == "gt":
+            elif str.lower(self.unit) == "gt":
                 # get area
                 if rgi_area_version == 6:
                     glacier_area = self.region.rgi6_area
@@ -428,11 +428,11 @@ class Timeseries():
             raise NotImplementedError("Version '{}' of RGI is not implemented yet.".format(rgi_area_version))
 
         object_copy = self.copy()
-        object_copy.unit = "gt"
+        object_copy.unit = "Gt"
 
-        if self.unit == "gt":  # no conversion needed as already in gt
+        if str.lower(self.unit) == "gt":  # no conversion needed as already in gt
             return self.copy()
-        elif self.unit == "mwe":
+        elif str.lower(self.unit) == "mwe":
             object_copy.data.changes = np.array(meters_water_equivalent_to_gigatonnes(
                 self.data.changes, area_km2=glacier_area, density_of_water=density_of_water))
             # variables for uncertainty calculation

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -805,7 +805,5 @@ class Timeseries():
             object_copy.data.end_dates = np.array(df_nan_removed["end_dates"])
             object_copy.data.changes = np.array(df_nan_removed["changes"])
             object_copy.data.errors = np.array(df_nan_removed["errors"])
-            object_copy.data.glacier_area_observed = np.array(df_nan_removed["glacier_area_observed"])
-            object_copy.data.glacier_area_reference = np.array(df_nan_removed["glacier_area_reference"])
 
         return object_copy

--- a/glambie/plot/plot_helpers.py
+++ b/glambie/plot/plot_helpers.py
@@ -226,7 +226,8 @@ def finalise_save_to_file_and_close_plot(output_filepath: str):
 def add_labels_axlines_and_title(axes: mpl.pyplot.axes,
                                  unit: str,
                                  title: str,
-                                 legend_fontsize: int = 9):
+                                 legend_fontsize: int = 9,
+                                 legend_outside_plot: bool = True):
     """
     Extend plot with labels, legend etc.:
     - Adds labels to axes with units
@@ -244,12 +245,18 @@ def add_labels_axlines_and_title(axes: mpl.pyplot.axes,
         plot title
     legend_fontsize : int, optional
         legend font size, by default 9
+    legend_outside_plot : bool, optional
+        if True the legend is plotted outside the plot. good for when there are many datasets in on plot
+        by default True
     """
     axes[0].set_title(title)
     axes[0].axhline(0, color="grey", linewidth=0.9, linestyle="--")
     axes[0].set_xlabel("Time")
     axes[0].set_ylabel("Change [{} per year]".format(unit))
     axes[1].axhline(0, color="grey", linewidth=0.9, linestyle="--")
-    axes[1].legend(fontsize=legend_fontsize)
+    if legend_outside_plot:
+        axes[1].legend(bbox_to_anchor=(1.04, 1), borderaxespad=0, fontsize=legend_fontsize)
+    else:
+        axes[1].legend(fontsize=legend_fontsize)
     axes[1].set_xlabel("Time")
     axes[1].set_ylabel("Cumulative change [{}]".format(unit))

--- a/glambie/plot/processing_plots.py
+++ b/glambie/plot/processing_plots.py
@@ -125,7 +125,7 @@ def plot_raw_input_data_of_data_group(catalogue_raw: DataCatalogue,
             label="Dataset: " + ds.user_group)
 
     add_labels_axlines_and_title(
-        axes=axes, unit=catalogue_raw.datasets[0].unit, legend_fontsize=7,
+        axes=axes, unit=trend_combined.unit, legend_fontsize=7,
         title="{} - {} - {}: raw input data".format(region.long_name, data_group.long_name, category))
     finalise_save_to_file_and_close_plot(output_filepath)
 
@@ -139,7 +139,7 @@ def plot_raw_and_homogenized_input_data_of_data_group(catalogue_raw: DataCatalog
                                                       output_filepath: str,
                                                       plot_errors: bool = True):
     _, axes = plt.subplots(2, 1, figsize=(7, 6))
-    colours = get_colours(len(catalogue_raw.datasets))
+    colours = get_colours(len(catalogue_homogenized.datasets))
 
     # plot non-cumulative timeseries
     for count, ds in enumerate(catalogue_raw.datasets):
@@ -153,18 +153,19 @@ def plot_raw_and_homogenized_input_data_of_data_group(catalogue_raw: DataCatalog
             plot_errors=plot_errors, label="Dataset (homog.): " + ds.user_group)
 
     # plot cumulative timeseries
-    for count, (ds_raw, ds_homog) in enumerate(zip(catalogue_raw.datasets, catalogue_homogenized.datasets)):
+    for count, ds_raw in enumerate(catalogue_raw.datasets):
         plot_cumulative_timeseries_on_axis(
             timeseries=ds_raw, ax=axes[1], colour=colours[count], plot_errors=plot_errors, linestyle="-",
             timeseries_for_vertical_adjustment=trend_combined,
             label="Dataset (raw): " + ds_raw.user_group)
+    for count, ds_homog in enumerate(catalogue_homogenized.datasets):
         plot_cumulative_timeseries_on_axis(
             timeseries=ds_homog, ax=axes[1], colour=colours[count], plot_errors=plot_errors, linestyle="--",
             timeseries_for_vertical_adjustment=trend_combined,
             label="Dataset (homog.): " + ds_homog.user_group)
 
     add_labels_axlines_and_title(
-        axes=axes, unit=catalogue_raw.datasets[0].unit, legend_fontsize=7,
+        axes=axes, unit=trend_combined.unit, legend_fontsize=7,
         title="{} - {} - {}: raw input data".format(region.long_name, data_group.long_name, category))
     finalise_save_to_file_and_close_plot(output_filepath)
 

--- a/glambie/plot/processing_plots.py
+++ b/glambie/plot/processing_plots.py
@@ -31,7 +31,7 @@ def plot_all_plots_for_region_data_group_processing(output_path_handler: OutputP
                                       region=region,
                                       category="annual",
                                       output_filepath=plot_fp,
-                                      plot_errors=True)
+                                      plot_errors=False)
     # Convert to same unit as annual datasets now
     data_catalogue_annual_raw = convert_datasets_to_monthly_grid(data_catalogue_annual_raw)
     data_catalogue_annual_raw = convert_datasets_to_unit_mwe(data_catalogue_annual_raw)

--- a/glambie/plot/processing_plots.py
+++ b/glambie/plot/processing_plots.py
@@ -125,7 +125,7 @@ def plot_raw_input_data_of_data_group(catalogue_raw: DataCatalogue,
             label="Dataset: " + ds.user_group)
 
     add_labels_axlines_and_title(
-        axes=axes, unit=catalogue_raw.datasets[0].unit, legend_fontsize=9,
+        axes=axes, unit=catalogue_raw.datasets[0].unit, legend_fontsize=7,
         title="{} - {} - {}: raw input data".format(region.long_name, data_group.long_name, category))
     finalise_save_to_file_and_close_plot(output_filepath)
 
@@ -150,7 +150,7 @@ def plot_raw_and_homogenized_input_data_of_data_group(catalogue_raw: DataCatalog
     for count, ds in enumerate(catalogue_homogenized.datasets):
         plot_non_cumulative_timeseries_on_axis(
             result_dataframe=ds.data.as_dataframe(), ax=axes[0], colour=colours[count], linestyle="--",
-            plot_errors=plot_errors, label="Dataset (raw): " + ds.user_group)
+            plot_errors=plot_errors, label="Dataset (homog.): " + ds.user_group)
 
     # plot cumulative timeseries
     for count, (ds_raw, ds_homog) in enumerate(zip(catalogue_raw.datasets, catalogue_homogenized.datasets)):
@@ -161,10 +161,10 @@ def plot_raw_and_homogenized_input_data_of_data_group(catalogue_raw: DataCatalog
         plot_cumulative_timeseries_on_axis(
             timeseries=ds_homog, ax=axes[1], colour=colours[count], plot_errors=plot_errors, linestyle="--",
             timeseries_for_vertical_adjustment=trend_combined,
-            label="Dataset: " + ds_homog.user_group)
+            label="Dataset (homog.): " + ds_homog.user_group)
 
     add_labels_axlines_and_title(
-        axes=axes, unit=catalogue_raw.datasets[0].unit, legend_fontsize=9,
+        axes=axes, unit=catalogue_raw.datasets[0].unit, legend_fontsize=7,
         title="{} - {} - {}: raw input data".format(region.long_name, data_group.long_name, category))
     finalise_save_to_file_and_close_plot(output_filepath)
 
@@ -192,7 +192,7 @@ def plot_homogenized_input_data_of_data_group(catalogue_annual: DataCatalogue,
             label="Dataset: " + ds.user_group)
 
     add_labels_axlines_and_title(
-        axes=axes, unit=catalogue_annual.datasets[0].unit, legend_fontsize=9,
+        axes=axes, unit=catalogue_annual.datasets[0].unit, legend_fontsize=7,
         title="{} - {}: homogenized input data".format(region.long_name, data_group.long_name))
     finalise_save_to_file_and_close_plot(output_filepath)
 
@@ -256,7 +256,7 @@ def plot_recalibration_of_annual_variability_with_trends(catalogue_trends: DataC
     # plot cumulative
     for count, (trends, annual) in enumerate(zip(catalogue_trends.datasets, catalogue_calibrated_series.datasets)):
         plot_cumulative_timeseries_on_axis(
-            timeseries=trends, ax=axes[1], colour=colours[count], plot_errors=plot_errors, linestyle="--",
+            timeseries=trends, ax=axes[1], colour=colours[count], plot_errors=plot_errors,
             timeseries_for_vertical_adjustment=trend_combined,
             label="Trend: " + trends.user_group)
         plot_cumulative_timeseries_on_axis(
@@ -269,7 +269,7 @@ def plot_recalibration_of_annual_variability_with_trends(catalogue_trends: DataC
         title="{} - {}: recalibration with trends".format(region.long_name, data_group.long_name), legend_fontsize=7)
 
     add_labels_axlines_and_title(
-        axes=axes, unit=catalogue_trends.datasets[0].unit, legend_fontsize=9,
+        axes=axes, unit=catalogue_trends.datasets[0].unit, legend_fontsize=7,
         title="{} - {}: recalibration with trends".format(region.long_name, data_group.long_name))
     finalise_save_to_file_and_close_plot(output_filepath)
 
@@ -299,14 +299,14 @@ def plot_recalibrated_result_of_data_group(catalogue_trends: DataCatalogue,
         plot_cumulative_timeseries_on_axis(
             timeseries=timeseries, ax=axes[1], colour=colours[count], plot_errors=plot_errors, linestyle="--",
             timeseries_for_vertical_adjustment=trend_combined,
-            label="Calibrated annual series: {}".format(ds.user_group))
+            label="Calibrated annual series: {}".format(timeseries.user_group))
 
     plot_cumulative_timeseries_on_axis(
         timeseries=trend_combined, ax=axes[1], colour="black", plot_errors=plot_errors, linestyle="--",
         timeseries_for_vertical_adjustment=None,
         label="{} - combined solution".format(data_group.long_name))
 
-    add_labels_axlines_and_title(axes=axes, unit=catalogue_trends.datasets[0].unit, legend_fontsize=9,
+    add_labels_axlines_and_title(axes=axes, unit=catalogue_trends.datasets[0].unit, legend_fontsize=7,
                                  title="{} - {}: combined solution".format(region.long_name, data_group.long_name))
     finalise_save_to_file_and_close_plot(output_filepath)
 
@@ -344,7 +344,7 @@ def plot_combination_of_sources_within_region(catalogue_results: DataCatalogue,
         label="Consensus estimate")
 
     add_labels_axlines_and_title(axes=axes, unit=combined_timeseries.unit,
-                                 title="{}: combined estimate".format(region.long_name), legend_fontsize=9)
+                                 title="{}: combined estimate".format(region.long_name), legend_fontsize=7)
     finalise_save_to_file_and_close_plot(output_filepath)
 
 
@@ -380,5 +380,5 @@ def plot_combination_of_regions_to_global(catalogue_region_results: DataCatalogu
         timeseries_for_vertical_adjustment=None, label="Global estimate")
 
     add_labels_axlines_and_title(axes=axes, unit=global_timeseries.unit,
-                                 title="{}: combined estimate".format(region.long_name), legend_fontsize=9)
+                                 title="{}: combined estimate".format(region.long_name), legend_fontsize=7)
     finalise_save_to_file_and_close_plot(output_filepath)

--- a/glambie/plot/processing_plots.py
+++ b/glambie/plot/processing_plots.py
@@ -31,7 +31,7 @@ def plot_all_plots_for_region_data_group_processing(output_path_handler: OutputP
                                       region=region,
                                       category="annual",
                                       output_filepath=plot_fp,
-                                      plot_errors=False)
+                                      plot_errors=True)
     # Convert to same unit as annual datasets now
     data_catalogue_annual_raw = convert_datasets_to_monthly_grid(data_catalogue_annual_raw)
     data_catalogue_annual_raw = convert_datasets_to_unit_mwe(data_catalogue_annual_raw)
@@ -188,7 +188,7 @@ def plot_homogenized_input_data_of_data_group(catalogue_annual: DataCatalogue,
     # plot non-cumulative timeseries
     for count, ds in enumerate(catalogue_annual.datasets):
         plot_non_cumulative_timeseries_on_axis(
-            result_dataframe=ds.data.as_dataframe(), ax=axes[0], colour=colours[count], plot_errors=False,
+            result_dataframe=ds.data.as_dataframe(), ax=axes[0], colour=colours[count], plot_errors=plot_errors,
             label="Dataset: " + ds.user_group)
 
     # plot cumulative timeseries

--- a/glambie/plot/processing_plots.py
+++ b/glambie/plot/processing_plots.py
@@ -32,6 +32,7 @@ def plot_all_plots_for_region_data_group_processing(output_path_handler: OutputP
                                       category="annual",
                                       output_filepath=plot_fp,
                                       plot_errors=False)
+    # Convert to same unit as annual datasets now
     data_catalogue_annual_raw = convert_datasets_to_monthly_grid(data_catalogue_annual_raw)
     data_catalogue_annual_raw = convert_datasets_to_unit_mwe(data_catalogue_annual_raw)
     plot_fp = output_path_handler.get_plot_output_file_path(region=region, data_group=data_group,
@@ -108,7 +109,7 @@ def plot_raw_input_data_of_data_group(catalogue_raw: DataCatalogue,
                                       category: str,
                                       output_filepath: str,
                                       plot_errors: bool = True):
-    _, axes = plt.subplots(2, 1, figsize=(7, 6))
+    _, axes = plt.subplots(2, 1, figsize=(11, 6))
     colours = get_colours(len(catalogue_raw.datasets))
 
     # plot non-cumulative timeseries
@@ -124,8 +125,13 @@ def plot_raw_input_data_of_data_group(catalogue_raw: DataCatalogue,
             timeseries_for_vertical_adjustment=trend_combined,
             label="Dataset: " + ds.user_group)
 
+    if len(catalogue_raw.datasets) > 0:
+        unit = catalogue_raw.datasets[0].unit
+    else:
+        unit = "unknown"
+
     add_labels_axlines_and_title(
-        axes=axes, unit=trend_combined.unit, legend_fontsize=7,
+        axes=axes, unit=unit, legend_fontsize=7,
         title="{} - {} - {}: raw input data".format(region.long_name, data_group.long_name, category))
     finalise_save_to_file_and_close_plot(output_filepath)
 
@@ -138,31 +144,31 @@ def plot_raw_and_homogenized_input_data_of_data_group(catalogue_raw: DataCatalog
                                                       category: str,
                                                       output_filepath: str,
                                                       plot_errors: bool = True):
-    _, axes = plt.subplots(2, 1, figsize=(7, 6))
+    _, axes = plt.subplots(2, 1, figsize=(10, 6))
     colours = get_colours(len(catalogue_homogenized.datasets))
 
     # plot non-cumulative timeseries
     for count, ds in enumerate(catalogue_raw.datasets):
         plot_non_cumulative_timeseries_on_axis(
             result_dataframe=ds.data.as_dataframe(), ax=axes[0], colour=colours[count], plot_errors=plot_errors,
-            label="Dataset (raw): " + ds.user_group)
+            label="Raw: " + ds.user_group, linestyle=(0, (1, 1)))
 
     for count, ds in enumerate(catalogue_homogenized.datasets):
         plot_non_cumulative_timeseries_on_axis(
-            result_dataframe=ds.data.as_dataframe(), ax=axes[0], colour=colours[count], linestyle="--",
-            plot_errors=plot_errors, label="Dataset (homog.): " + ds.user_group)
+            result_dataframe=ds.data.as_dataframe(), ax=axes[0], colour=colours[count], linestyle="-",
+            plot_errors=plot_errors, label="Homog.: " + ds.user_group)
 
     # plot cumulative timeseries
     for count, ds_raw in enumerate(catalogue_raw.datasets):
         plot_cumulative_timeseries_on_axis(
-            timeseries=ds_raw, ax=axes[1], colour=colours[count], plot_errors=plot_errors, linestyle="-",
+            timeseries=ds_raw, ax=axes[1], colour=colours[count], plot_errors=plot_errors, linestyle=(0, (1, 1)),
             timeseries_for_vertical_adjustment=trend_combined,
-            label="Dataset (raw): " + ds_raw.user_group)
+            label="Raw: " + ds_raw.user_group)
     for count, ds_homog in enumerate(catalogue_homogenized.datasets):
         plot_cumulative_timeseries_on_axis(
-            timeseries=ds_homog, ax=axes[1], colour=colours[count], plot_errors=plot_errors, linestyle="--",
+            timeseries=ds_homog, ax=axes[1], colour=colours[count], plot_errors=plot_errors, linestyle="-",
             timeseries_for_vertical_adjustment=trend_combined,
-            label="Dataset (homog.): " + ds_homog.user_group)
+            label="Homog.: " + ds_homog.user_group)
 
     add_labels_axlines_and_title(
         axes=axes, unit=trend_combined.unit, legend_fontsize=7,
@@ -176,7 +182,7 @@ def plot_homogenized_input_data_of_data_group(catalogue_annual: DataCatalogue,
                                               region: RGIRegion,
                                               output_filepath: str,
                                               plot_errors: bool = True):
-    _, axes = plt.subplots(2, 1, figsize=(7, 6))
+    _, axes = plt.subplots(2, 1, figsize=(10, 6))
     colours = get_colours(len(catalogue_annual.datasets))
 
     # plot non-cumulative timeseries
@@ -204,7 +210,7 @@ def plot_annual_variability_of_data_group(catalogue_annual_anomalies: DataCatalo
                                           region: RGIRegion,
                                           output_filepath: str,
                                           plot_errors: bool = True):
-    _, axes = plt.subplots(2, 1, figsize=(7, 6))
+    _, axes = plt.subplots(2, 1, figsize=(10, 6))
     colours = get_colours(len(catalogue_annual_anomalies.datasets))
 
     # plot non-cumulative timeseries
@@ -231,7 +237,7 @@ def plot_annual_variability_of_data_group(catalogue_annual_anomalies: DataCatalo
 
     add_labels_axlines_and_title(
         axes=axes, unit=catalogue_annual_anomalies.datasets[0].unit, legend_fontsize=7,
-        title="{} - {}: annual variability".format(region.long_name, data_group.long_name))
+        title="{} - {}: annual anomalies".format(region.long_name, data_group.long_name))
     finalise_save_to_file_and_close_plot(output_filepath)
 
 
@@ -242,7 +248,7 @@ def plot_recalibration_of_annual_variability_with_trends(catalogue_trends: DataC
                                                          region: RGIRegion,
                                                          output_filepath: str,
                                                          plot_errors: bool = True):
-    _, axes = plt.subplots(2, 1, figsize=(7, 6))
+    _, axes = plt.subplots(2, 1, figsize=(10, 6))
     colours = get_colours(len(catalogue_trends.datasets))
 
     # plot non-cumulative timeseries
@@ -282,7 +288,7 @@ def plot_recalibrated_result_of_data_group(catalogue_trends: DataCatalogue,
                                            region: RGIRegion,
                                            output_filepath: str,
                                            plot_errors: bool = True):
-    _, axes = plt.subplots(2, 1, figsize=(7, 6))
+    _, axes = plt.subplots(2, 1, figsize=(10, 6))
     colours = get_colours(len(catalogue_trends.datasets))
 
     # plot non-cumulative
@@ -318,7 +324,7 @@ def plot_combination_of_sources_within_region(catalogue_results: DataCatalogue,
                                               output_filepath: str,
                                               plot_errors: bool = True):
 
-    _, axes = plt.subplots(2, 1, figsize=(7, 6))
+    _, axes = plt.subplots(2, 1, figsize=(10, 6))
     colours = get_colours(len(catalogue_results.datasets))
 
     # plot non-cumulative
@@ -355,7 +361,7 @@ def plot_combination_of_regions_to_global(catalogue_region_results: DataCatalogu
                                           output_filepath: str,
                                           plot_errors: bool = True):
 
-    _, axes = plt.subplots(2, 1, figsize=(7, 6))
+    _, axes = plt.subplots(2, 1, figsize=(10, 6))
     colours = get_colours(len(catalogue_region_results.datasets))
 
     for count, timeseries in enumerate(catalogue_region_results.datasets):

--- a/glambie/processing/main.py
+++ b/glambie/processing/main.py
@@ -72,8 +72,9 @@ def _run_regional_results(glambie_run_config: GlambieRunConfig,
         data_group_results_per_region.extend(results_one_region.datasets)
 
         # get combined regional results combining the individual data group results
-        combined_results = combine_within_one_region(results_one_region, output_path_handler)
-        combined_regional_results.append(combined_results)
+        if len(data_group_results_per_region) > 0:
+            combined_results = combine_within_one_region(results_one_region, output_path_handler)
+            combined_regional_results.append(combined_results)
 
     catalogue_data_group_results_per_region = DataCatalogue.from_list(
         data_group_results_per_region)

--- a/glambie/processing/path_handling.py
+++ b/glambie/processing/path_handling.py
@@ -36,7 +36,7 @@ class OutputPathHandler():
         str
             output folder path
         """
-        folder_path = os.path.join(self.base_path, region.name)
+        folder_path = os.path.join(self.base_path, f"{str(region.rgi_id)}_{region.name}")
         os.makedirs(folder_path, exist_ok=True)
         return folder_path
 
@@ -71,7 +71,7 @@ class OutputPathHandler():
         str
             output folder path
         """
-        folder_path = os.path.join(self.base_path, region.name, data_group.name)
+        folder_path = os.path.join(self.get_region_output_folder_path(region), data_group.name)
         os.makedirs(folder_path, exist_ok=True)
         return folder_path
 
@@ -94,7 +94,7 @@ class OutputPathHandler():
         str
             output file path of plot
         """
-        folder_path = os.path.join(self.base_path, region.name, data_group.name, "plots")
+        folder_path = os.path.join(self.get_region_output_folder_path(region), data_group.name, "plots")
         os.makedirs(folder_path, exist_ok=True)
         return os.path.join(folder_path, plot_file_name)
 
@@ -122,7 +122,7 @@ class OutputPathHandler():
         str
             output file path of csv
         """
-        folder_path = os.path.join(self.base_path, region.name, data_group.name, "csvs", subfolder)
+        folder_path = os.path.join(self.get_region_output_folder_path(region), data_group.name, "csvs", subfolder)
         os.makedirs(folder_path, exist_ok=True)
         return os.path.join(folder_path, csv_file_name)
 

--- a/glambie/processing/process_global_results.py
+++ b/glambie/processing/process_global_results.py
@@ -6,6 +6,7 @@ from glambie.data.timeseries import Timeseries, TimeseriesData
 from glambie.const.constants import YearType
 from glambie.processing.path_handling import OutputPathHandler
 from glambie.processing.processing_helpers import prepare_seasonal_calibration_dataset
+from glambie.processing.processing_helpers import get_reduced_catalogue_to_date_window
 from glambie.const.data_groups import GLAMBIE_DATA_GROUPS
 from glambie.plot.processing_plots import plot_combination_of_regions_to_global
 import numpy as np
@@ -42,15 +43,11 @@ def run_global_results(glambie_run_config: GlambieRunConfig,
     regional_results_catalogue_homogenized = _homogenize_regional_results_to_calendar_year(glambie_run_config,
                                                                                            regional_results_catalogue,
                                                                                            original_data_catalogue)
-    # remove any dates outside config timeperiod:
-    for dataset in regional_results_catalogue_homogenized.datasets:
-        df = dataset.data.as_dataframe()
-        df = df[((df.end_dates <= glambie_run_config.end_year) & (
-            df.start_dates >= glambie_run_config.start_year))].reset_index(drop=True)
-        dataset.data.start_dates = np.array(df["start_dates"])
-        dataset.data.end_dates = np.array(df["end_dates"])
-        dataset.data.changes = np.array(df["changes"])
-        dataset.data.errors = np.array(df["errors"])
+    # remove any dates outside config time period:
+    regional_results_catalogue_homogenized = get_reduced_catalogue_to_date_window(
+        data_catalogue=regional_results_catalogue_homogenized,
+        start_date=glambie_run_config.start_year,
+        end_date=glambie_run_config.end_year)
 
     global_timeseries = _combine_regional_results_into_global(regional_results_catalogue_homogenized)
     # plot

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -10,6 +10,8 @@ from glambie.processing.processing_helpers import convert_datasets_to_annual_tre
 from glambie.processing.processing_helpers import filter_catalogue_with_config_settings
 from glambie.processing.processing_helpers import prepare_seasonal_calibration_dataset
 from glambie.processing.processing_helpers import extend_annual_timeseries_if_outside_trends_period
+from glambie.processing.processing_helpers import check_and_handle_gaps_in_timeseries
+from glambie.processing.processing_helpers import set_unneeded_columns_to_nan
 from glambie.processing.output_helpers import save_all_csvs_for_region_data_group_processing
 from glambie.data.data_catalogue_helpers import calibrate_timeseries_with_trends_catalogue
 from glambie.plot.processing_plots import plot_all_plots_for_region_data_group_processing
@@ -66,6 +68,8 @@ def run_one_region(glambie_run_config: GlambieRunConfig,
         data_catalogue_trends.load_all_data()
         data_catalogue_annual = convert_datasets_to_monthly_grid(data_catalogue_annual)
         data_catalogue_trends = convert_datasets_to_monthly_grid(data_catalogue_trends)
+        data_catalogue_annual = set_unneeded_columns_to_nan(data_catalogue_annual)
+        data_catalogue_trends = set_unneeded_columns_to_nan(data_catalogue_trends)
 
         # run annual and trends calibration timeseries for region
         trend_combined = _run_region_timeseries_one_source(data_catalogue_annual=data_catalogue_annual,
@@ -156,6 +160,9 @@ def _run_region_timeseries_one_source(data_catalogue_annual: DataCatalogue,
     Timeseries
         timeseries of combined dataset
     """
+    # handle gaps in timeseries
+    data_catalogue_annual = check_and_handle_gaps_in_timeseries(data_catalogue_annual)
+    data_catalogue_trends = check_and_handle_gaps_in_timeseries(data_catalogue_trends)
 
     data_catalogue_annual_raw = data_catalogue_annual
     data_catalogue_trends_raw = data_catalogue_trends

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -88,6 +88,9 @@ def run_one_region(glambie_run_config: GlambieRunConfig,
                 region=trend_combined.region, data_group=data_group,
                 csv_file_name=f"{data_group.name}_final_with_area_change.csv"))
             result_datasets.append(trend_combined)
+        else:
+            log.info('Skipping to process region=%s datagroup=%s as no data found.',
+                     region_config.region_name, data_group.name)
 
     result_catalogue = DataCatalogue.from_list(result_datasets, base_path=data_catalogue.base_path)
     return result_catalogue

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -52,7 +52,8 @@ def filter_catalogue_with_config_settings(data_group: GlambieDataGroup,
     exclude_annual_datasets = region_config.region_run_settings[data_group.name].get("exclude_annual_datasets", [])
     log.info('Excluding the following datasets from ANNUAL calculations: datasets=%s', exclude_annual_datasets)
     for ds in exclude_annual_datasets:
-        datasets_annual = [d for d in datasets_annual if d.user_group.lower() != ds.lower()]
+        if ds is not None:
+            datasets_annual = [d for d in datasets_annual if d.user_group.lower() != ds.lower()]
     if data_group == GLAMBIE_DATA_GROUPS["demdiff_and_glaciological"]:
         datasets_annual = [d for d in datasets_annual if d.data_group != GLAMBIE_DATA_GROUPS["demdiff"]]
 
@@ -61,7 +62,8 @@ def filter_catalogue_with_config_settings(data_group: GlambieDataGroup,
     exclude_trend_datasets = region_config.region_run_settings[data_group.name].get("exclude_trend_datasets", [])
     log.info('Excluding the following datasets from TREND calculations: datasets=%s', exclude_trend_datasets)
     for ds in exclude_trend_datasets:
-        datasets_trend = [d for d in datasets_trend if d.user_group.lower() != ds.lower()]
+        if ds is not None:
+            datasets_trend = [d for d in datasets_trend if d.user_group.lower() != ds.lower()]
     if data_group == GLAMBIE_DATA_GROUPS["demdiff_and_glaciological"]:
         datasets_trend = [d for d in datasets_trend if d.data_group != GLAMBIE_DATA_GROUPS["glaciological"]]
 

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -289,7 +289,7 @@ def check_and_handle_gaps_in_timeseries(data_catalogue: DataCatalogue) -> DataCa
             for idx, split_timeseries in enumerate(split_dataframes):
                 timeseries_copy = timeseries.copy()
                 # rename user group name to be unique
-                timeseries_copy.user_group = + f"{timeseries_copy.user_group }_{idx}"
+                timeseries_copy.user_group = f"{timeseries_copy.user_group }_{str(idx+1)}"
                 timeseries_copy.data.changes = np.array(split_timeseries["changes"])
                 timeseries_copy.data.errors = np.array(split_timeseries["errors"])
                 timeseries_copy.data.start_dates = np.array(split_timeseries["start_dates"])

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -286,14 +286,14 @@ def check_and_handle_gaps_in_timeseries(data_catalogue: DataCatalogue) -> DataCa
             df_data = timeseries.data.as_dataframe()
             split_dataframes = slice_timeseries_at_gaps(df_data)
             # 2 add split timeseries to new_datasets
-            for split_timeseries in split_dataframes:
+            for idx, split_timeseries in enumerate(split_dataframes):
                 timeseries_copy = timeseries.copy()
+                # rename user group name to be unique
+                timeseries_copy.user_group = + f"{timeseries_copy.user_group }_{idx}"
                 timeseries_copy.data.changes = np.array(split_timeseries["changes"])
                 timeseries_copy.data.errors = np.array(split_timeseries["errors"])
                 timeseries_copy.data.start_dates = np.array(split_timeseries["start_dates"])
                 timeseries_copy.data.end_dates = np.array(split_timeseries["end_dates"])
-                timeseries_copy.data.glacier_area_observed = None
-                timeseries_copy.data.glacier_area_reference = None
                 new_datasets.append(timeseries_copy)
         else:  # or else append original
             new_datasets.append(timeseries)
@@ -330,3 +330,27 @@ def slice_timeseries_at_gaps(df_timeseries: pd.DataFrame) -> list[pd.DataFrame]:
     # plus append last / full split in the end
     split_timeseries_dataframes.append(df_timeseries.iloc[previous_index:].reset_index(drop=True))
     return split_timeseries_dataframes
+
+
+def set_unneeded_columns_to_nan(data_catalogue: DataCatalogue) -> DataCatalogue:
+    """
+    Sets data columns of TimeseriesData not needed in algorithm to NaN within a DataCatalogue
+    to simplify object manipulating
+
+    Parameters
+    ----------
+    data_catalogue : DataCatalogue
+        input data catalogue with Timeseries datasets to be manipulated
+
+    Returns
+    -------
+    DataCatalogue
+        manipulated data catalogue
+    """
+    result_catalogue = data_catalogue.copy()
+    for timeseries in result_catalogue.datasets:
+        timeseries.data.glacier_area_observed = None
+        timeseries.data.glacier_area_reference = None
+        timeseries.data.hydrological_correction_value = None
+        timeseries.data.remarks = None
+    return result_catalogue

--- a/glambie/util/timeseries_helpers.py
+++ b/glambie/util/timeseries_helpers.py
@@ -421,7 +421,7 @@ def derivative_to_cumulative(start_dates: list[float],
     """
     dates = np.array([start_dates[0], *end_dates])
     if calculate_as_errors:
-        changes = np.array([0, *np.sqrt(pd.Series(np.square(changes)).cumsum())])
+        changes = np.array([0, *np.array(pd.Series(np.square(changes)).cumsum())**0.5])
     else:
         changes = np.array([0, *np.array(pd.Series(changes).cumsum())])
     if return_type == "arrays":

--- a/glambie/util/timeseries_helpers.py
+++ b/glambie/util/timeseries_helpers.py
@@ -394,7 +394,8 @@ def combine_timeseries_imbie(t_array: list[np.ndarray],
 def derivative_to_cumulative(start_dates: list[float],
                              end_dates: list[float],
                              changes: list[float],
-                             return_type="arrays"):
+                             return_type: str = "arrays",
+                             calculate_as_errors: bool = False):
     """
     Calculates a cumulative timeseries from a list of non cumulative changes between start and end date
 
@@ -408,6 +409,9 @@ def derivative_to_cumulative(start_dates: list[float],
         changes between start and end date
     return_type : str, optional
         type in which the result is returned. Current options are: 'arrays' and 'dataframe', by default 'arrays'
+    calculate_as_errors : bool, optional
+        if True it will calculate cumulative errors rather than changes
+        assuming errors of each timestep are independent
 
     Returns
     -------
@@ -416,14 +420,21 @@ def derivative_to_cumulative(start_dates: list[float],
         'dataframe': pd.DataFrame({'dates': dates, 'changes': changes})
     """
     dates = np.array([start_dates[0], *end_dates])
-    changes = np.array([0, *np.array(pd.Series(changes).cumsum())])
+    if calculate_as_errors:
+        changes = np.array([0, *np.sqrt(pd.Series(np.square(changes)).cumsum())])
+    else:
+        changes = np.array([0, *np.array(pd.Series(changes).cumsum())])
     if return_type == "arrays":
         return dates, changes
     elif return_type == "dataframe":
-        df_cumulative = pd.DataFrame({'dates': dates,
-                                      'changes': changes,
-                                      })
-        return df_cumulative
+        if calculate_as_errors:
+            return pd.DataFrame({'dates': dates,
+                                 'errors': changes,
+                                 })
+        else:
+            return pd.DataFrame({'dates': dates,
+                                 'changes': changes,
+                                 })
 
 
 def cumulative_to_derivative(fractional_year_array, cumulative_changes, return_type="arrays"):

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -208,7 +208,7 @@ def test_convert_timeseries_to_unit_gt_no_area_change_rate(example_timeseries_in
     example_timeseries_ingested.unit = "mwe"
     example_timeseries_ingested.region = REGIONS["iceland"]
     converted_timeseries = example_timeseries_ingested.convert_timeseries_to_unit_gt()
-    assert converted_timeseries.unit == "gt"
+    assert str.lower(converted_timeseries.unit) == "gt"
     assert example_timeseries_ingested.unit == "mwe"
     assert not np.array_equal(converted_timeseries.data.changes, example_timeseries_ingested.data.changes)
     area = example_timeseries_ingested.region.rgi6_area

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -449,3 +449,14 @@ def test_raises_assertion_error_when_converting_to_gt_with_area_change_applied(e
     timeseries_area_change = example_timeseries_ingested.apply_area_change(rgi_area_version=6, apply_change=True)
     with pytest.raises(AssertionError):
         timeseries_area_change.convert_timeseries_to_unit_gt()
+
+
+def test_reduce_to_date_window(example_timeseries_ingested):
+    reduced_timeseries = example_timeseries_ingested.reduce_to_date_window(start_date=2010.0, end_date=2010.2)
+    assert np.array_equal(reduced_timeseries.data.changes, example_timeseries_ingested.data.changes[:-1])
+    assert np.array_equal(reduced_timeseries.data.errors, example_timeseries_ingested.data.errors[:-1])
+    assert np.array_equal(reduced_timeseries.data.start_dates, example_timeseries_ingested.data.start_dates[:-1])
+    reduced_timeseries = example_timeseries_ingested.reduce_to_date_window(start_date=2010.2, end_date=2010.5)
+    assert np.array_equal(reduced_timeseries.data.changes, example_timeseries_ingested.data.changes[1:])
+    assert np.array_equal(reduced_timeseries.data.errors, example_timeseries_ingested.data.errors[1:])
+    assert np.array_equal(reduced_timeseries.data.end_dates, example_timeseries_ingested.data.end_dates[1:])

--- a/tests/processing/test_path_handling.py
+++ b/tests/processing/test_path_handling.py
@@ -16,7 +16,7 @@ def test_get_region_output_folder_path(path_helper: OutputPathHandler, tmp_path:
     region_path = path_helper.get_region_output_folder_path(region=region)
     assert path_helper.base_path == tmp_path
     assert os.path.exists(region_path)
-    assert os.path.join(tmp_path, region.name) == region_path
+    assert os.path.join(tmp_path, f"{region.rgi_id}_{region.name}") == region_path
 
 
 def test_get_region_and_data_group_output_folder_path(path_helper: OutputPathHandler):

--- a/tests/processing/test_processing_helpers.py
+++ b/tests/processing/test_processing_helpers.py
@@ -1,5 +1,5 @@
 from glambie.processing.processing_helpers import filter_catalogue_with_config_settings
-from glambie.processing.processing_helpers import split_timeseries_at_gaps
+from glambie.processing.processing_helpers import slice_timeseries_at_gaps
 from glambie.processing.processing_helpers import check_and_handle_gaps_in_timeseries
 from glambie.const.data_groups import GLAMBIE_DATA_GROUPS
 from glambie.data.data_catalogue import DataCatalogue
@@ -141,11 +141,11 @@ def test_filter_catalogue_with_config_settings_demdiff_and_glaciological(example
     assert any(d.user_group == "sloths" for d in datasets_trend.datasets)
 
 
-def test_split_timeseries_at_gaps():
+def test_slice_timeseries_at_gaps():
     ts = pd.DataFrame({"start_dates": [2012, 2013, 2015, 2016, 2020],
                        "end_dates": [2013, 2014, 2016, 2017, 2023],
                        "changes": [2, 3, 4, 5, 6]})
-    split_ts_result = split_timeseries_at_gaps(ts)
+    split_ts_result = slice_timeseries_at_gaps(ts)
     expected_split_ts_result = [
         pd.DataFrame({"start_dates": [2012, 2013],
                       "end_dates": [2013, 2014],

--- a/tests/processing/test_processing_helpers.py
+++ b/tests/processing/test_processing_helpers.py
@@ -78,6 +78,7 @@ def example_catalogue_filled():
                            remarks=None)
     ts1 = Timeseries(rgi_version=6,
                      unit='mwe',
+                     user_group="a",
                      data_group=GLAMBIE_DATA_GROUPS['consensus'],
                      data=data1,
                      region=REGIONS["iceland"])
@@ -91,6 +92,7 @@ def example_catalogue_filled():
                            remarks=None)
     ts2 = Timeseries(rgi_version=6,
                      unit='mwe',
+                     user_group="b",
                      data_group=GLAMBIE_DATA_GROUPS['consensus'],
                      data=data2,
                      region=REGIONS["svalbard"])

--- a/tests/processing/test_processing_helpers.py
+++ b/tests/processing/test_processing_helpers.py
@@ -1,9 +1,15 @@
 from glambie.processing.processing_helpers import filter_catalogue_with_config_settings
+from glambie.processing.processing_helpers import split_timeseries_at_gaps
+from glambie.processing.processing_helpers import check_and_handle_gaps_in_timeseries
 from glambie.const.data_groups import GLAMBIE_DATA_GROUPS
 from glambie.data.data_catalogue import DataCatalogue
+from glambie.data.timeseries import TimeseriesData, Timeseries
 from glambie.config.config_classes import GlambieRunConfig
+from glambie.const.regions import REGIONS
 import pytest
 import os
+import pandas as pd
+import numpy as np
 
 
 @pytest.fixture()
@@ -61,6 +67,37 @@ def example_catalogue_2():
 
 
 @pytest.fixture()
+def example_catalogue_filled():
+    data1 = TimeseriesData(start_dates=[2010, 2011, 2012],
+                           end_dates=[2011, 2012, 2018],
+                           changes=np.array([2., 5., 7.]),
+                           errors=np.array([1., 1.2, 1.3]),
+                           glacier_area_reference=np.array([None, None]),
+                           glacier_area_observed=np.array([None, None]),
+                           hydrological_correction_value=None,
+                           remarks=None)
+    ts1 = Timeseries(rgi_version=6,
+                     unit='mwe',
+                     data_group=GLAMBIE_DATA_GROUPS['consensus'],
+                     data=data1,
+                     region=REGIONS["iceland"])
+    data2 = TimeseriesData(start_dates=[2010, 2011],
+                           end_dates=[2011, 2012],
+                           changes=np.array([3., 4.]),
+                           errors=np.array([0.9, 1.1]),
+                           glacier_area_reference=np.array([None, None]),
+                           glacier_area_observed=np.array([None, None]),
+                           hydrological_correction_value=None,
+                           remarks=None)
+    ts2 = Timeseries(rgi_version=6,
+                     unit='mwe',
+                     data_group=GLAMBIE_DATA_GROUPS['consensus'],
+                     data=data2,
+                     region=REGIONS["svalbard"])
+    return DataCatalogue.from_list([ts1, ts2])
+
+
+@pytest.fixture()
 def glambie_config():
     yaml_abspath = os.path.join('tests', 'test_data', 'configs', 'test_config.yaml')
     return GlambieRunConfig.from_yaml(yaml_abspath)
@@ -102,3 +139,37 @@ def test_filter_catalogue_with_config_settings_demdiff_and_glaciological(example
     assert all(d.user_group != "sharks" for d in datasets_trend.datasets)
     assert all(d.data_group != GLAMBIE_DATA_GROUPS["glaciological"] for d in datasets_trend.datasets)
     assert any(d.user_group == "sloths" for d in datasets_trend.datasets)
+
+
+def test_split_timeseries_at_gaps():
+    ts = pd.DataFrame({"start_dates": [2012, 2013, 2015, 2016, 2020],
+                       "end_dates": [2013, 2014, 2016, 2017, 2023],
+                       "changes": [2, 3, 4, 5, 6]})
+    split_ts_result = split_timeseries_at_gaps(ts)
+    expected_split_ts_result = [
+        pd.DataFrame({"start_dates": [2012, 2013],
+                      "end_dates": [2013, 2014],
+                      "changes": [2, 3]}),
+        pd.DataFrame({"start_dates": [2015, 2016],
+                      "end_dates": [2016, 2017],
+                      "changes": [4, 5]}),
+        pd.DataFrame({"start_dates": [2020],
+                      "end_dates": [2023],
+                      "changes": [6]})]
+
+    for (calculated, expected) in zip(split_ts_result, expected_split_ts_result):
+        pd.testing.assert_frame_equal(calculated, expected)
+
+
+def test_check_and_handle_gaps_in_timeseries(example_catalogue_filled):
+    example_catalogue_filled.copy()
+    # introduce a gap
+    example_catalogue_filled.datasets[
+        1].data.start_dates[1] = example_catalogue_filled.datasets[1].data.start_dates[1] + 0.5
+    assert not example_catalogue_filled.datasets[1].data.is_cumulative_valid()
+    result_catalogue = check_and_handle_gaps_in_timeseries(example_catalogue_filled)
+    # now we should have one more dataset as it has been split up due to the gap
+    assert len(result_catalogue.datasets) == len(example_catalogue_filled.datasets) + 1
+    # and no more gaps in the data
+    for dataset in result_catalogue.datasets:
+        assert dataset.data.is_cumulative_valid()

--- a/tests/util/test_timeseries_helpers.py
+++ b/tests/util/test_timeseries_helpers.py
@@ -173,6 +173,20 @@ def test_derivative_to_cumulative():
     pd.testing.assert_series_equal(df["changes"], pd.Series([0., 3., 4., 5.], name="changes"))
 
 
+def test_derivative_to_cumulative_errors():
+    start_dates = [2010, 2011, 2012]
+    end_dates = [2011, 2012, 2013]
+    derivative_errors = [3., 1., 2.]
+    dates, changes = derivative_to_cumulative(start_dates, end_dates, derivative_errors, return_type="arrays",
+                                              calculate_as_errors=True)
+    assert np.array_equal(dates, np.array([2010, 2011, 2012, 2013]))
+    assert np.array_equal(changes, np.array([0., 3., 10**0.5, 14**0.5]))
+    # also check returntype dataframe works
+    df = derivative_to_cumulative(start_dates, end_dates, derivative_errors, return_type="dataframe",
+                                  calculate_as_errors=True)
+    pd.testing.assert_series_equal(df["errors"], pd.Series([0., 3., 10**0.5, 14**0.5], name="errors"))
+
+
 def test_derivative_to_cumulative_and_back_gives_initial_input_again():
     start_dates = [2010, 2011, 2012]
     end_dates = [2011, 2012, 2013]


### PR DESCRIPTION
Handle gaps in timeseries and a bunch of other small fixes:
- Handle cases where there is a gap in the timeseries by splitting up the timeseries at the gap within the processing chain
- Implementation to convert timeseries from Gt to mwe, so that we can now process GRACE timeseries as well
- Dealing with regions and data sources that have no data within the processing chain (ignoring it, or if we only have a trend and no annual dataset we use an auxiliary dataset for the annual variability)
- Plot fixes (wrong units displayed, label and title fixes, legend on the side of plots etc.)
- Cumulative uncertainties now calculated for cumulative timeseries, assuming that uncertainties of each timestep are independent
- minimum and maximum dates now read from config files and removed if outside period