### PR TITLE
Added notebook to save out summary plots showing edits made to submitted datasets

### DIFF
--- a/glambie/notebooks/save_summary_plots_pre_and_post_edits.ipynb
+++ b/glambie/notebooks/save_summary_plots_pre_and_post_edits.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import matplotlib.pyplot as plt\n",
+    "from glambie.data.data_catalogue import DataCatalogue\n",
+    "from glambie.plot.plot_helpers import get_colours, add_labels_axlines_and_title\n",
+    "from glambie.plot.plot_helpers import plot_non_cumulative_timeseries_on_axis, plot_cumulative_timeseries_on_axis\n",
+    "from glambie.data import submission_system_interface"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# read bucket catalogue - files used by algorithms\n",
+    "catalogue_bucket = DataCatalogue.from_glambie_submission_system()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# read original unedited files (from ox)\n",
+    "catalogue_unedited_submissions = DataCatalogue.from_json_file('/data/ox1/working/glambie/local_copies_of_submitted_data/original_files_pre_edits/meta.json')\n",
+    "catalogue_unedited_submissions.load_all_data()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's print all datasets in Alaska\n",
+    "for d in catalogue_unedited_submissions.datasets:\n",
+    "    print(f\"{d.region.name} \\t {d.data_group.name} \\t {d.user_group}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plots_path = '/data/ox1/working/glambie/glambie_submissions_summary_plots'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After the conversion to the annual grid is fixed, we can also add this plotting function here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for original_dataset in catalogue_unedited_submissions.datasets:\n",
+    "\n",
+    "    print(f\"{original_dataset.region.name} \\t {original_dataset.data_group.name} \\t {original_dataset.user_group} \\t {original_dataset.unit}\")\n",
+    "    \n",
+    "    # Find corresponding dataset in bucket\n",
+    "    for bf in catalogue_bucket.datasets:\n",
+    "        if (original_dataset.region.name == bf.region.name) and (original_dataset.user_group == bf.user_group):\n",
+    "            bucket_dataset = bf\n",
+    "\n",
+    "    # Generate timeseries for plotting\n",
+    "    print(original_dataset.unit)\n",
+    "    original_dataset_in_mwe = original_dataset.convert_timeseries_to_unit_mwe()  # get dataset into mwe\n",
+    "    print(original_dataset_in_mwe.data)\n",
+    "    bucket_dataset_in_mwe = bucket_dataset.convert_timeseries_to_unit_mwe()\n",
+    "    \n",
+    "    # First we need to convert it to our evenly spaced grid\n",
+    "    # original_dataset_date_grid = original_dataset_in_mwe.convert_timeseries_to_monthly_grid()\n",
+    "    # original_dataset_annual = original_dataset_date_grid.convert_timeseries_to_annual_trends()\n",
+    "    # bucket_dataset_date_grid = bucket_dataset_in_mwe.convert_timeseries_to_monthly_grid()\n",
+    "    # bucket_dataset_annual = bucket_dataset_date_grid.convert_timeseries_to_annual_trends()\n",
+    "\n",
+    "    # Convert to a longterm_trend\n",
+    "    # original_dataset_trend = original_dataset_date_grid.convert_timeseries_to_longterm_trend()\n",
+    "    # bucket_dataset_trend = bucket_dataset_date_grid.convert_timeseries_to_longterm_trend()\n",
+    "    \n",
+    "    # Comparison plot\n",
+    "    plot_errors=False # set to True if you want to plot error bars\n",
+    "\n",
+    "    _, axes = plt.subplots(2, 1, figsize=(11, 6))\n",
+    "    colours = get_colours(3)\n",
+    "\n",
+    "    # plot non-cumulative timeseries\n",
+    "    plot_non_cumulative_timeseries_on_axis(\n",
+    "        result_dataframe=original_dataset_in_mwe.data.as_dataframe(), ax=axes[0], colour=colours[0], plot_errors=plot_errors)\n",
+    "    # plot_non_cumulative_timeseries_on_axis(\n",
+    "        # result_dataframe=bucket_dataset_annual.data.as_dataframe(), ax=axes[0], colour=colours[1], plot_errors=plot_errors)\n",
+    "    # plot_non_cumulative_timeseries_on_axis(\n",
+    "        # result_dataframe=bucket_dataset_trend.data.as_dataframe(), ax=axes[0], colour=colours[2], plot_errors=plot_errors)\n",
+    "    plot_non_cumulative_timeseries_on_axis(\n",
+    "        result_dataframe=bucket_dataset_in_mwe.data.as_dataframe(), ax=axes[0], colour=colours[1], plot_errors=plot_errors)\n",
+    "    \n",
+    "    \n",
+    "    # plot cumulative timeseries\n",
+    "    plot_cumulative_timeseries_on_axis(\n",
+    "        timeseries=original_dataset_in_mwe, ax=axes[1], colour=colours[0], plot_errors=plot_errors, linestyle=\"-\",\n",
+    "        timeseries_for_vertical_adjustment=None, label=\"Original dataset (as submitted): \" + original_dataset_in_mwe.user_group)\n",
+    "    # plot_cumulative_timeseries_on_axis(\n",
+    "        # timeseries=bucket_dataset_annual, ax=axes[1], colour=colours[1], plot_errors=plot_errors, linestyle=\"-\",\n",
+    "        # timeseries_for_vertical_adjustment=bucket_dataset_in_mwe, # vertically adjust to original dataset\n",
+    "        # label=\"Annual rates: \" + bucket_dataset_annual.user_group)\n",
+    "    # plot_cumulative_timeseries_on_axis(\n",
+    "        # timeseries=bucket_dataset_trend, ax=axes[1], colour=colours[2], plot_errors=plot_errors, linestyle=\"-\",\n",
+    "        # timeseries_for_vertical_adjustment=bucket_dataset_in_mwe, # vertically adjust to original dataset\n",
+    "        # label=\"Trend: \" + bucket_dataset_trend.user_group)\n",
+    "    plot_cumulative_timeseries_on_axis(\n",
+    "        timeseries=bucket_dataset_in_mwe, ax=axes[1], colour=colours[1], plot_errors=plot_errors, linestyle=\"-\",\n",
+    "        timeseries_for_vertical_adjustment=None, label=\"GlAMBIE dataset (edited): \" + bucket_dataset_in_mwe.user_group)\n",
+    "\n",
+    "    add_labels_axlines_and_title(\n",
+    "        axes=axes, unit=bucket_dataset.unit, legend_fontsize=9,\n",
+    "        title=\"\")\n",
+    "    \n",
+    "    figname = str(original_dataset.region.name) + '_' + str(original_dataset.data_group.name) + '_' + str(original_dataset.user_group) + '.png'\n",
+    "    \n",
+    "    plt.tight_layout()\n",
+    "    plt.savefig(os.path.join(plots_path, figname))\n",
+    "    plt.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "glambie",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Quick PR to add a notebook that can be run once after making necessary edits to submitted files to make them compliant with the expected glambie data format. A plot will be saved out for each submission showing the original data as submitted, and the data after edits made by 'read_and_edit_bucket_csv_files.py'.

Note: Timeseries converted to regular grid is currently not included on the plots as there is an issue with this method for some of the datasets - but will be included once fixed.