### PR TITLE
Fixes for running the combined glambie datasets

### DIFF
--- a/configuration/2_western_canada_us.yaml
+++ b/configuration/2_western_canada_us.yaml
@@ -4,10 +4,10 @@ region_name: western_canada_us
 year_type: glaciological # glaciological or calendar
 
 seasonal_correction_dataset:
-  user_group: Huss_monthly
-  data_group: combined
-  # user_group: UZH_GlaciolSineWave
-  # data_group: glaciological
+  # user_group: Huss_monthly
+  # data_group: combined
+  user_group: UZH_GlaciolSineWave
+  data_group: glaciological
 
 region_run_settings:
   altimetry:
@@ -15,7 +15,7 @@ region_run_settings:
     - Menounos_WNA_alt1
     - Menounos_WNA_is2gedi
     exclude_trend_datasets :
-    - Menounos_WNA_is2gedi
+    - 
   gravimetry:
     exclude_annual_datasets :
     - 

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -221,8 +221,11 @@ class DataCatalogue():
         bool
             True if all dataset units are the same, False otherwise
         """
-        unit = self.datasets[0].unit
-        return all(dataset.unit == unit for dataset in self.datasets)
+        if len(self.datasets) > 0:
+            unit = self.datasets[0].unit
+            return all(dataset.unit == unit for dataset in self.datasets)
+        else:
+            return True
 
     def average_timeseries_in_catalogue(self, remove_trend: bool = True, add_trend_after_averaging: bool = False,
                                         out_data_group: GlambieDataGroup = GLAMBIE_DATA_GROUPS["consensus"]) \

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -592,8 +592,8 @@ class Timeseries():
 
         return object_copy  # return copy of itself
 
-    def convert_timeseries_to_annual_trends(self,
-                                            year_type: constants.YearType = constants.YearType.CALENDAR) -> Timeseries:
+    def convert_timeseries_to_annual_trends(
+            self, year_type: constants.YearType = constants.YearType.CALENDAR) -> Timeseries:
         """
         Converts a timeseries to annual trends. Note that this assumes that the timeseries is already using the annual
         grid for resolutions >= 1 year and the monthly grid for resolutions <= 1 year.

--- a/glambie/plot/processing_plots.py
+++ b/glambie/plot/processing_plots.py
@@ -25,6 +25,13 @@ def plot_all_plots_for_region_data_group_processing(output_path_handler: OutputP
                                                     ):
     plot_fp = output_path_handler.get_plot_output_file_path(region=region, data_group=data_group,
                                                             plot_file_name="1_annual_input_data.png")
+    # if not all datasets are the same unit they need to be converted to mwe for plotting
+    # otherwise the plots are very confusing
+    if not data_catalogue_annual_raw.datasets_are_same_unit():  # annual
+        data_catalogue_annual_raw = convert_datasets_to_unit_mwe(data_catalogue_annual_raw)
+    if not data_catalogue_trends_raw.datasets_are_same_unit():  # trends
+        data_catalogue_trends_raw = convert_datasets_to_unit_mwe(data_catalogue_trends_raw)
+
     plot_raw_input_data_of_data_group(catalogue_raw=data_catalogue_annual_raw,
                                       trend_combined=timeseries_trend_combined,
                                       data_group=data_group,
@@ -33,7 +40,7 @@ def plot_all_plots_for_region_data_group_processing(output_path_handler: OutputP
                                       output_filepath=plot_fp,
                                       plot_errors=False)
     # Convert to same unit as annual datasets now
-    data_catalogue_annual_raw = convert_datasets_to_monthly_grid(data_catalogue_annual_raw)
+    # data_catalogue_annual_raw = convert_datasets_to_monthly_grid(data_catalogue_annual_raw)
     data_catalogue_annual_raw = convert_datasets_to_unit_mwe(data_catalogue_annual_raw)
     plot_fp = output_path_handler.get_plot_output_file_path(region=region, data_group=data_group,
                                                             plot_file_name="2_annual_homogenize_data_2.png")
@@ -300,7 +307,7 @@ def plot_recalibrated_result_of_data_group(catalogue_trends: DataCatalogue,
 
     plot_non_cumulative_timeseries_on_axis(
         result_dataframe=trend_combined.data.as_dataframe(), ax=axes[0], colour="black", linestyle="--",
-        label="{} - combined solution".format(data_group.long_name), plot_errors=plot_errors)
+        label="Consensus solution", plot_errors=plot_errors)
 
     # plot cumulative
     for count, timeseries in enumerate(catalogue_calibrated_series.datasets):
@@ -312,7 +319,7 @@ def plot_recalibrated_result_of_data_group(catalogue_trends: DataCatalogue,
     plot_cumulative_timeseries_on_axis(
         timeseries=trend_combined, ax=axes[1], colour="black", plot_errors=plot_errors, linestyle="--",
         timeseries_for_vertical_adjustment=None,
-        label="{} - combined solution".format(data_group.long_name))
+        label="Consensus solution")
 
     add_labels_axlines_and_title(axes=axes, unit=catalogue_trends.datasets[0].unit, legend_fontsize=7,
                                  title="{} - {}: combined solution".format(region.long_name, data_group.long_name))
@@ -344,7 +351,7 @@ def plot_combination_of_sources_within_region(catalogue_results: DataCatalogue,
         plot_cumulative_timeseries_on_axis(
             timeseries=timeseries, ax=axes[1], colour=colours[count], plot_errors=plot_errors, linestyle="-",
             timeseries_for_vertical_adjustment=combined_timeseries,
-            label="{} - combined solution".format(timeseries.data_group.long_name))
+            label="{} - solution".format(timeseries.data_group.long_name))
 
     # plot combined solution
     plot_cumulative_timeseries_on_axis(

--- a/glambie/plot/processing_plots.py
+++ b/glambie/plot/processing_plots.py
@@ -40,7 +40,6 @@ def plot_all_plots_for_region_data_group_processing(output_path_handler: OutputP
                                       output_filepath=plot_fp,
                                       plot_errors=False)
     # Convert to same unit as annual datasets now
-    # data_catalogue_annual_raw = convert_datasets_to_monthly_grid(data_catalogue_annual_raw)
     data_catalogue_annual_raw = convert_datasets_to_unit_mwe(data_catalogue_annual_raw)
     plot_fp = output_path_handler.get_plot_output_file_path(region=region, data_group=data_group,
                                                             plot_file_name="2_annual_homogenize_data_2.png")

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -75,14 +75,16 @@ def run_one_region(glambie_run_config: GlambieRunConfig,
             data_catalogue_trends = set_unneeded_columns_to_nan(data_catalogue_trends)
 
             # run annual and trends calibration timeseries for region
-            trend_combined = _run_region_timeseries_one_source(data_catalogue_annual=data_catalogue_annual,
-                                                               data_catalogue_trends=data_catalogue_trends,
-                                                               seasonal_calibration_dataset=season_calibration_dataset,
-                                                               annual_backup_dataset=annual_backup_dataset,
-                                                               year_type=region_config.year_type,
-                                                               region=REGIONS[region_config.region_name],
-                                                               data_group=data_group,
-                                                               output_path_handler=output_path_handler)
+            trend_combined = _run_region_timeseries_one_source(
+                data_catalogue_annual=data_catalogue_annual,
+                data_catalogue_trends=data_catalogue_trends,
+                seasonal_calibration_dataset=season_calibration_dataset,
+                annual_backup_dataset=annual_backup_dataset,
+                year_type=region_config.year_type,
+                region=REGIONS[region_config.region_name],
+                data_group=data_group,
+                output_path_handler=output_path_handler,
+                min_max_time_window_for_longterm_trends=[glambie_run_config.start_year, glambie_run_config.end_year])
             # apply area change
             trend_combined = trend_combined.apply_or_remove_area_change(rgi_area_version=6, apply_area_change=True)
             # save out with area change applied

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -214,7 +214,7 @@ def _run_region_timeseries_one_source(
         object to handle output path. If set to None, no plots / other data will be saved
     min_max_time_window_for_longterm_trends : Tuple[float, float], optional
         if specified, the time series are filtered by the time window before the longterm trend is extracted,
-        meaning that the resulting longterm trends are within the minimum and maximum of the time window
+        meaning that the resulting longterm trends are within the minimum and maximum of the time window.
         Note that existing longterm trends are removed if they are outside the time window.
         the dates are expected in decimal years format (float), e.g. 2012.75
 

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -213,7 +213,10 @@ def _run_region_timeseries_one_source(
     output_path_handler : OutputPathHandler
         object to handle output path. If set to None, no plots / other data will be saved
     min_max_time_window_for_longterm_trends : Tuple[float, float], optional
-        if specified, longterm trends are not exceeding these dates
+        if specified, the time series are filtered by the time window before the longterm trend is axtracted,
+        meaning that the resulting longterm trends are within the minimum and maximum of the time window
+        Note that existing longterm trends are removed if the are outside the time window
+        the dates are expected in decimal years format (float), e.g. 2012.75
 
     Returns
     -------
@@ -267,7 +270,7 @@ def _run_region_timeseries_one_source(
     data_catalogue_trends = convert_datasets_to_longterm_trends_in_unit_mwe(
         data_catalogue_trends, year_type=year_type,
         season_calibration_dataset=seasonal_calibration_dataset,
-        min_max_time_window=min_max_time_window_for_longterm_trends)
+        output_trend_date_range=min_max_time_window_for_longterm_trends)
 
     # now treat case where trends are outside annual combined timeseries
     annual_combined_full_ext = extend_annual_timeseries_if_outside_trends_period(

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -215,7 +215,7 @@ def _run_region_timeseries_one_source(
     min_max_time_window_for_longterm_trends : Tuple[float, float], optional
         if specified, the time series are filtered by the time window before the longterm trend is extracted,
         meaning that the resulting longterm trends are within the minimum and maximum of the time window
-        Note that existing longterm trends are removed if the are outside the time window
+        Note that existing longterm trends are removed if they are outside the time window.
         the dates are expected in decimal years format (float), e.g. 2012.75
 
     Returns

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -216,7 +216,7 @@ def _run_region_timeseries_one_source(
         if specified, the time series are filtered by the time window before the longterm trend is extracted,
         meaning that the resulting longterm trends are within the minimum and maximum of the time window.
         Note that existing longterm trends are removed if they are outside the time window.
-        the dates are expected in decimal years format (float), e.g. 2012.75
+        The dates are expected in decimal years format (float), e.g. 2012.75.
 
     Returns
     -------

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -213,7 +213,7 @@ def _run_region_timeseries_one_source(
     output_path_handler : OutputPathHandler
         object to handle output path. If set to None, no plots / other data will be saved
     min_max_time_window_for_longterm_trends : Tuple[float, float], optional
-        if specified, the time series are filtered by the time window before the longterm trend is axtracted,
+        if specified, the time series are filtered by the time window before the longterm trend is extracted,
         meaning that the resulting longterm trends are within the minimum and maximum of the time window
         Note that existing longterm trends are removed if the are outside the time window
         the dates are expected in decimal years format (float), e.g. 2012.75

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -106,10 +106,8 @@ def convert_datasets_to_annual_trends(data_catalogue: DataCatalogue,
     ----------
     data_catalogue : DataCatalogue
         data catalogue to be converted
-
     year_type : YearType
         type of annual year, e.g hydrological or calendar
-
     season_calibration_dataset: Timeseries
         Timeseries dataset for seasonal calibration if trends are at annual resolution.
 
@@ -132,8 +130,9 @@ def convert_datasets_to_annual_trends(data_catalogue: DataCatalogue,
     return catalogue_annual_grid
 
 
-def convert_datasets_to_longterm_trends(data_catalogue: DataCatalogue, year_type: YearType,
-                                        season_calibration_dataset: Timeseries) -> DataCatalogue:
+def convert_datasets_to_longterm_trends_in_unit_mwe(data_catalogue: DataCatalogue, year_type: YearType,
+                                                    season_calibration_dataset: Timeseries,
+                                                    min_max_time_window: Tuple[float, float] = None) -> DataCatalogue:
     """
     Convert all datasets in data catalogue to longterm trends.
     If dataset in catalogue has a lower resolution than a year, seasonal homogenization is used.
@@ -143,12 +142,14 @@ def convert_datasets_to_longterm_trends(data_catalogue: DataCatalogue, year_type
     ----------
     data_catalogue : DataCatalogue
         data catalogue to be converted
-
     year_type : YearType
         type of annual year when longterm timeseries should start and end, e.g hydrological or calendar
-
     season_calibration_dataset: Timeseries
         Timeseries dataset for seasonal calibration if trends are at lower resolution than 1 year.
+    min_max_time_window : Tuple[float, float], optional
+        Tuple[min_start_date, max_end_date]
+        If specified, the longterm trend will not start earlier than this date min_start_date and
+        end later than max_end_date
 
     Returns
     -------
@@ -159,13 +160,26 @@ def convert_datasets_to_longterm_trends(data_catalogue: DataCatalogue, year_type
     data_catalogue_original = data_catalogue.copy()
     datasets = []
     for idx, ds in enumerate(data_catalogue.datasets):
+        # remove any dates outside minimum and maximum
+        if min_max_time_window is not None:
+            ds.reduce_to_date_window(start_date=min_max_time_window[0], end_date=min_max_time_window[1])
+        # seasonal correction if resolution higher than 1 year
         if data_catalogue_original.datasets[idx].data.max_temporal_resolution > 1:
             ds = data_catalogue_original.datasets[idx].convert_timeseries_to_unit_mwe()
             datasets.append(ds.convert_timeseries_using_seasonal_homogenization(
                 seasonal_calibration_dataset=season_calibration_dataset, year_type=year_type, p_value=0))
+        # if resolution 1 year, read longterm trend and then apply seasonal correction after
+        elif data_catalogue_original.datasets[idx].data.max_temporal_resolution == 1:
+            ds = ds.convert_timeseries_to_longterm_trend()
+            ds = data_catalogue_original.datasets[idx].convert_timeseries_to_unit_mwe()
+            datasets.append(ds.convert_timeseries_using_seasonal_homogenization(
+                seasonal_calibration_dataset=season_calibration_dataset, year_type=year_type, p_value=0))
+        # Else read from lower resolution timeseries
+        # note that this assumes we now have monthly resolution.
+        # The case that we have datasets that are < 1 year but > monthly they will need to be handled here in the future
         else:
             ds = ds.convert_timeseries_to_annual_trends(year_type=year_type)
-            datasets.append(ds.convert_timeseries_to_longterm_trend())
+            datasets.append(ds.convert_timeseries_to_longterm_trend().convert_timeseries_to_unit_mwe())
     catalogue_trends = DataCatalogue.from_list(datasets, base_path=data_catalogue.base_path)
     return catalogue_trends
 

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -150,7 +150,7 @@ def convert_datasets_to_longterm_trends_in_unit_mwe(
     min_max_time_window : Tuple[float, float], optional
         If specified, the time series are filtered by the time window before the longterm trend is extracted,
         meaning that the resulting longterm trends are within the minimum and maximum of the time window.
-        Note that existing longterm trends are removed if the are outside the time window
+        Note that existing longterm trends are removed if the are outside the time window.
         The dates are expected in decimal years format (float), e.g. 2012.75.
 
     Returns

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -148,7 +148,7 @@ def convert_datasets_to_longterm_trends_in_unit_mwe(
     season_calibration_dataset: Timeseries
         Timeseries dataset for seasonal calibration if trends are at lower resolution than 1 year.
     min_max_time_window : Tuple[float, float], optional
-        if specified, the time series are filtered by the time window before the longterm trend is axtracted,
+        If specified, the time series are filtered by the time window before the longterm trend is extracted,
         meaning that the resulting longterm trends are within the minimum and maximum of the time window.
         Note that existing longterm trends are removed if the are outside the time window
         the dates are expected in decimal years format (float), e.g. 2012.75

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -162,7 +162,7 @@ def convert_datasets_to_longterm_trends_in_unit_mwe(data_catalogue: DataCatalogu
     for idx, ds in enumerate(data_catalogue.datasets):
         # remove any dates outside minimum and maximum
         if min_max_time_window is not None:
-            ds.reduce_to_date_window(start_date=min_max_time_window[0], end_date=min_max_time_window[1])
+            ds = ds.reduce_to_date_window(start_date=min_max_time_window[0], end_date=min_max_time_window[1])
         # seasonal correction if resolution higher than 1 year
         if data_catalogue_original.datasets[idx].data.max_temporal_resolution > 1:
             ds = data_catalogue_original.datasets[idx].convert_timeseries_to_unit_mwe()
@@ -171,10 +171,10 @@ def convert_datasets_to_longterm_trends_in_unit_mwe(data_catalogue: DataCatalogu
         # if resolution 1 year, read longterm trend and then apply seasonal correction after
         elif data_catalogue_original.datasets[idx].data.max_temporal_resolution == 1:
             ds = ds.convert_timeseries_to_longterm_trend()
-            ds = data_catalogue_original.datasets[idx].convert_timeseries_to_unit_mwe()
+            ds = ds.convert_timeseries_to_unit_mwe()
             datasets.append(ds.convert_timeseries_using_seasonal_homogenization(
                 seasonal_calibration_dataset=season_calibration_dataset, year_type=year_type, p_value=0))
-        # Else read from lower resolution timeseries
+        # else read from lower resolution timeseries
         # note that this assumes we now have monthly resolution.
         # The case that we have datasets that are < 1 year but > monthly they will need to be handled here in the future
         else:

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -151,7 +151,7 @@ def convert_datasets_to_longterm_trends_in_unit_mwe(
         If specified, the time series are filtered by the time window before the longterm trend is extracted,
         meaning that the resulting longterm trends are within the minimum and maximum of the time window.
         Note that existing longterm trends are removed if the are outside the time window
-        the dates are expected in decimal years format (float), e.g. 2012.75
+        The dates are expected in decimal years format (float), e.g. 2012.75.
 
     Returns
     -------

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -130,9 +130,10 @@ def convert_datasets_to_annual_trends(data_catalogue: DataCatalogue,
     return catalogue_annual_grid
 
 
-def convert_datasets_to_longterm_trends_in_unit_mwe(data_catalogue: DataCatalogue, year_type: YearType,
-                                                    season_calibration_dataset: Timeseries,
-                                                    min_max_time_window: Tuple[float, float] = None) -> DataCatalogue:
+def convert_datasets_to_longterm_trends_in_unit_mwe(
+        data_catalogue: DataCatalogue, year_type: YearType,
+        season_calibration_dataset: Timeseries,
+        output_trend_date_range: Tuple[float, float] = None) -> DataCatalogue:
     """
     Convert all datasets in data catalogue to longterm trends.
     If dataset in catalogue has a lower resolution than a year, seasonal homogenization is used.
@@ -147,9 +148,10 @@ def convert_datasets_to_longterm_trends_in_unit_mwe(data_catalogue: DataCatalogu
     season_calibration_dataset: Timeseries
         Timeseries dataset for seasonal calibration if trends are at lower resolution than 1 year.
     min_max_time_window : Tuple[float, float], optional
-        Tuple[min_start_date, max_end_date]
-        If specified, the longterm trend will not start earlier than this date min_start_date and
-        end later than max_end_date
+        if specified, the time series are filtered by the time window before the longterm trend is axtracted,
+        meaning that the resulting longterm trends are within the minimum and maximum of the time window.
+        Note that existing longterm trends are removed if the are outside the time window
+        the dates are expected in decimal years format (float), e.g. 2012.75
 
     Returns
     -------
@@ -157,29 +159,32 @@ def convert_datasets_to_longterm_trends_in_unit_mwe(data_catalogue: DataCatalogu
         New data catalogue with converted data
     """
     data_catalogue = convert_datasets_to_monthly_grid(data_catalogue)
-    data_catalogue_original = data_catalogue.copy()
     datasets = []
-    for idx, ds in enumerate(data_catalogue.datasets):
+    for original_dataset in data_catalogue.datasets:
+        temporal_resolution = original_dataset.data.max_temporal_resolution
         # remove any dates outside minimum and maximum
-        if min_max_time_window is not None:
-            ds = ds.reduce_to_date_window(start_date=min_max_time_window[0], end_date=min_max_time_window[1])
+        if output_trend_date_range is not None:
+            ds = original_dataset.reduce_to_date_window(start_date=output_trend_date_range[0],
+                                                        end_date=output_trend_date_range[1])
+        else:
+            ds = original_dataset
+
         # seasonal correction if resolution higher than 1 year
-        if data_catalogue_original.datasets[idx].data.max_temporal_resolution > 1:
-            ds = data_catalogue_original.datasets[idx].convert_timeseries_to_unit_mwe()
-            datasets.append(ds.convert_timeseries_using_seasonal_homogenization(
-                seasonal_calibration_dataset=season_calibration_dataset, year_type=year_type, p_value=0))
+        if temporal_resolution > 1:
+            ds = ds.convert_timeseries_to_unit_mwe().convert_timeseries_using_seasonal_homogenization(
+                seasonal_calibration_dataset=season_calibration_dataset, year_type=year_type, p_value=0)
         # if resolution 1 year, read longterm trend and then apply seasonal correction after
-        elif data_catalogue_original.datasets[idx].data.max_temporal_resolution == 1:
-            ds = ds.convert_timeseries_to_longterm_trend()
-            ds = ds.convert_timeseries_to_unit_mwe()
-            datasets.append(ds.convert_timeseries_using_seasonal_homogenization(
-                seasonal_calibration_dataset=season_calibration_dataset, year_type=year_type, p_value=0))
+        elif temporal_resolution == 1:
+            ds = ds.convert_timeseries_to_longterm_trend().convert_timeseries_to_unit_mwe()
+            ds = ds.convert_timeseries_using_seasonal_homogenization(
+                seasonal_calibration_dataset=season_calibration_dataset, year_type=year_type, p_value=0)
         # else read from lower resolution timeseries
         # note that this assumes we now have monthly resolution.
         # The case that we have datasets that are < 1 year but > monthly they will need to be handled here in the future
         else:
             ds = ds.convert_timeseries_to_annual_trends(year_type=year_type)
-            datasets.append(ds.convert_timeseries_to_longterm_trend().convert_timeseries_to_unit_mwe())
+            ds = ds.convert_timeseries_to_longterm_trend().convert_timeseries_to_unit_mwe()
+        datasets.append(ds)
     catalogue_trends = DataCatalogue.from_list(datasets, base_path=data_catalogue.base_path)
     return catalogue_trends
 


### PR DESCRIPTION
A number of small bug fixes and adaptations detected when running the GlaMBIE combined datasets:
- long-term trends from annual rates were not calculated correctly when seasonal homogenization needed to be performed (this was never the case in any of the other datasets)
- long-term trends were calculated over the whole submitted period rather than the one specified in the config (again this was never an issue with the other datasets)
- the raw dataset plots need to convert all units to the same. Again never an issue except for the combined group as in the other data source groups the unit is the same anyways