### PR TITLE
Add-combined-datasets-to-other-data-sources

### DIFF
--- a/configuration/10_north_asia.yaml
+++ b/configuration/10_north_asia.yaml
@@ -26,3 +26,9 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/10_north_asia.yaml
+++ b/configuration/10_north_asia.yaml
@@ -19,7 +19,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/11_central_europe.yaml
+++ b/configuration/11_central_europe.yaml
@@ -26,3 +26,9 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/11_central_europe.yaml
+++ b/configuration/11_central_europe.yaml
@@ -19,7 +19,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/12_caucasus_middle_east.yaml
+++ b/configuration/12_caucasus_middle_east.yaml
@@ -26,3 +26,9 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/12_caucasus_middle_east.yaml
+++ b/configuration/12_caucasus_middle_east.yaml
@@ -19,7 +19,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/13_central_asia.yaml
+++ b/configuration/13_central_asia.yaml
@@ -28,3 +28,10 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss
+    - Miles2021

--- a/configuration/13_central_asia.yaml
+++ b/configuration/13_central_asia.yaml
@@ -21,7 +21,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/14_south_asia_west.yaml
+++ b/configuration/14_south_asia_west.yaml
@@ -28,3 +28,10 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss
+    - Miles2021

--- a/configuration/14_south_asia_west.yaml
+++ b/configuration/14_south_asia_west.yaml
@@ -21,7 +21,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/15_south_asia_east.yaml
+++ b/configuration/15_south_asia_east.yaml
@@ -28,3 +28,10 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss
+    - Miles2021

--- a/configuration/15_south_asia_east.yaml
+++ b/configuration/15_south_asia_east.yaml
@@ -21,7 +21,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/16_low_latitudes.yaml
+++ b/configuration/16_low_latitudes.yaml
@@ -26,3 +26,9 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/16_low_latitudes.yaml
+++ b/configuration/16_low_latitudes.yaml
@@ -19,7 +19,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/17_southern_andes.yaml
+++ b/configuration/17_southern_andes.yaml
@@ -26,3 +26,9 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/17_southern_andes.yaml
+++ b/configuration/17_southern_andes.yaml
@@ -19,7 +19,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/18_new_zealand.yaml
+++ b/configuration/18_new_zealand.yaml
@@ -26,3 +26,9 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/18_new_zealand.yaml
+++ b/configuration/18_new_zealand.yaml
@@ -19,7 +19,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/19_antarctic_and_subantarctic.yaml
+++ b/configuration/19_antarctic_and_subantarctic.yaml
@@ -17,7 +17,7 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - 
     exclude_trend_datasets :
     - 
   demdiff_and_glaciological :

--- a/configuration/19_antarctic_and_subantarctic.yaml
+++ b/configuration/19_antarctic_and_subantarctic.yaml
@@ -26,3 +26,9 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/1_alaska.yaml
+++ b/configuration/1_alaska.yaml
@@ -19,7 +19,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/1_alaska.yaml
+++ b/configuration/1_alaska.yaml
@@ -4,10 +4,10 @@ region_name: alaska
 year_type: glaciological # glaciological or calendar
 
 seasonal_correction_dataset:
-  user_group: Huss_monthly
-  data_group: combined
-  # user_group: UZH_GlaciolSineWave
-  # data_group: glaciological
+  # user_group: Huss_monthly
+  # data_group: combined
+  user_group: UZH_GlaciolSineWave
+  data_group: glaciological
 
 region_run_settings:
   altimetry:
@@ -20,9 +20,18 @@ region_run_settings:
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
     - Sasgen_AWIarc_gap
+    include_combined_trend_datasets:
+    - ArcticInSituvGRACE
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - ArcticInSituvGRACE
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/2_western_canada_us.yaml
+++ b/configuration/2_western_canada_us.yaml
@@ -20,7 +20,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/2_western_canada_us.yaml
+++ b/configuration/2_western_canada_us.yaml
@@ -27,3 +27,9 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/3_arctic_canada_north.yaml
+++ b/configuration/3_arctic_canada_north.yaml
@@ -21,7 +21,9 @@ region_run_settings:
     - LEGOS-MAG-bis_gap
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - LEGOS-MAGELLIUM_gap
+    - LEGOS-MAG-bis_gap
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/3_arctic_canada_north.yaml
+++ b/configuration/3_arctic_canada_north.yaml
@@ -15,6 +15,8 @@ region_run_settings:
     - Tepes
     exclude_trend_datasets :
     - 
+    include_combined_trend_datasets:
+    - Colgan2015
   gravimetry:
     exclude_annual_datasets :
     - LEGOS-MAGELLIUM_gap
@@ -26,6 +28,7 @@ region_run_settings:
     - Sasgen_AWIarc_gap
     include_combined_trend_datasets:
     - ArcticInSituvGRACE
+    - Colgan2015
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/3_arctic_canada_north.yaml
+++ b/configuration/3_arctic_canada_north.yaml
@@ -4,10 +4,10 @@ region_name: arctic_canada_north
 year_type: glaciological # glaciological or calendar
 
 seasonal_correction_dataset:
-  user_group: Huss_monthly
-  data_group: combined
-  # user_group: UZH_GlaciolSineWave
-  # data_group: glaciological
+  # user_group: Huss_monthly
+  # data_group: combined
+  user_group: UZH_GlaciolSineWave
+  data_group: glaciological
 
 region_run_settings:
   altimetry:
@@ -24,9 +24,18 @@ region_run_settings:
     - LEGOS-MAGELLIUM_gap
     - LEGOS-MAG-bis_gap
     - Sasgen_AWIarc_gap
+    include_combined_trend_datasets:
+    - ArcticInSituvGRACE
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - ArcticInSituvGRACE
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/4_arctic_canada_south.yaml
+++ b/configuration/4_arctic_canada_south.yaml
@@ -21,7 +21,9 @@ region_run_settings:
     - LEGOS-MAG-bis_gap
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - LEGOS-MAGELLIUM_gap
+    - LEGOS-MAG-bis_gap
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/4_arctic_canada_south.yaml
+++ b/configuration/4_arctic_canada_south.yaml
@@ -4,10 +4,10 @@ region_name: arctic_canada_south
 year_type: glaciological # glaciological or calendar
 
 seasonal_correction_dataset:
-  user_group: Huss_monthly
-  data_group: combined
-  # user_group: UZH_GlaciolSineWave
-  # data_group: glaciological
+  # user_group: Huss_monthly
+  # data_group: combined
+  user_group: UZH_GlaciolSineWave
+  data_group: glaciological
 
 region_run_settings:
   altimetry:
@@ -24,9 +24,18 @@ region_run_settings:
     - LEGOS-MAGELLIUM_gap
     - LEGOS-MAG-bis_gap
     - Sasgen_AWIarc_gap
+    include_combined_trend_datasets:
+    - ArcticInSituvGRACE
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - ArcticInSituvGRACE
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/4_arctic_canada_south.yaml
+++ b/configuration/4_arctic_canada_south.yaml
@@ -15,6 +15,8 @@ region_run_settings:
     - Tepes
     exclude_trend_datasets :
     - 
+    include_combined_trend_datasets:
+    - Colgan2015
   gravimetry:
     exclude_annual_datasets :
     - LEGOS-MAGELLIUM_gap
@@ -26,6 +28,7 @@ region_run_settings:
     - Sasgen_AWIarc_gap
     include_combined_trend_datasets:
     - ArcticInSituvGRACE
+    - Colgan2015
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/5_greenland_periphery.yaml
+++ b/configuration/5_greenland_periphery.yaml
@@ -16,11 +16,15 @@ region_run_settings:
     - Bolch_2013
     exclude_trend_datasets :
     - 
+    include_combined_trend_datasets:
+    - Colgan2015
   gravimetry:
     exclude_annual_datasets :
     - 
     exclude_trend_datasets :
     - 
+    include_combined_trend_datasets:
+    - Colgan2015
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/5_greenland_periphery.yaml
+++ b/configuration/5_greenland_periphery.yaml
@@ -27,3 +27,9 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/6_iceland.yaml
+++ b/configuration/6_iceland.yaml
@@ -4,10 +4,10 @@ region_name: iceland
 year_type: glaciological # glaciological or calendar
 
 seasonal_correction_dataset:
-  user_group: Huss_monthly
-  data_group: combined
-  # user_group: UZH_GlaciolSineWave
-  # data_group: glaciological
+  # user_group: Huss_monthly
+  # data_group: combined
+  user_group: UZH_GlaciolSineWave
+  data_group: glaciological
 
 region_run_settings:
   altimetry:
@@ -23,9 +23,22 @@ region_run_settings:
     - LEGOS-MAGELLIUM_gap
     - LEGOS-MAG-bis_gap
     - Sasgen_AWIarc_gap
+    include_combined_trend_datasets:
+    - ArcticInSituvGRACE
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - ArcticInSituvGRACE
+    - DUS-combined
+    - Huss
+    - Iceland-mb-group_tot
+    - Iceland-mb-group_smb
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss
+    - Iceland-mb-group_tot
+    - Iceland-mb-group_smb

--- a/configuration/6_iceland.yaml
+++ b/configuration/6_iceland.yaml
@@ -20,7 +20,9 @@ region_run_settings:
     - LEGOS-MAG-bis_gap
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - LEGOS-MAGELLIUM_gap
+    - LEGOS-MAG-bis_gap
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/7_svalbard.yaml
+++ b/configuration/7_svalbard.yaml
@@ -21,7 +21,9 @@ region_run_settings:
     - LEGOS-MAG-bis_gap
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - LEGOS-MAGELLIUM_gap
+    - LEGOS-MAG-bis_gap
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/7_svalbard.yaml
+++ b/configuration/7_svalbard.yaml
@@ -4,10 +4,10 @@ region_name: svalbard
 year_type: glaciological # glaciological or calendar
 
 seasonal_correction_dataset:
-  user_group: Huss_monthly
-  data_group: combined
-  # user_group: UZH_GlaciolSineWave
-  # data_group: glaciological
+  # user_group: Huss_monthly
+  # data_group: combined
+  user_group: UZH_GlaciolSineWave
+  data_group: glaciological
 
 region_run_settings:
   altimetry:
@@ -24,9 +24,18 @@ region_run_settings:
     - LEGOS-MAGELLIUM_gap
     - LEGOS-MAG-bis_gap
     - Sasgen_AWIarc_gap
+    include_combined_trend_datasets:
+    - ArcticInSituvGRACE
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - ArcticInSituvGRACE
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/8_scandinavia.yaml
+++ b/configuration/8_scandinavia.yaml
@@ -26,3 +26,9 @@ region_run_settings:
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/configuration/8_scandinavia.yaml
+++ b/configuration/8_scandinavia.yaml
@@ -19,7 +19,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/9_russian_arctic.yaml
+++ b/configuration/9_russian_arctic.yaml
@@ -21,7 +21,9 @@ region_run_settings:
     - LEGOS-MAG-bis_gap
     - Sasgen_AWIarc_gap
     exclude_trend_datasets :
-    - 
+    - LEGOS-MAGELLIUM_gap
+    - LEGOS-MAG-bis_gap
+    - Sasgen_AWIarc_gap
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/9_russian_arctic.yaml
+++ b/configuration/9_russian_arctic.yaml
@@ -4,10 +4,10 @@ region_name: russian_arctic
 year_type: glaciological # glaciological or calendar
 
 seasonal_correction_dataset:
-  user_group: Huss_monthly
-  data_group: combined
-  # user_group: UZH_GlaciolSineWave
-  # data_group: glaciological
+  # user_group: Huss_monthly
+  # data_group: combined
+  user_group: UZH_GlaciolSineWave
+  data_group: glaciological
 
 region_run_settings:
   altimetry:
@@ -24,9 +24,18 @@ region_run_settings:
     - LEGOS-MAGELLIUM_gap
     - LEGOS-MAG-bis_gap
     - Sasgen_AWIarc_gap
+    include_combined_trend_datasets:
+    - ArcticInSituvGRACE
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave
     - WGMS-mean_ba
     exclude_trend_datasets : # demdiff datasets
     - 
+    include_combined_annual_datasets:
+    - ArcticInSituvGRACE
+    - DUS-combined
+    - Huss
+    include_combined_trend_datasets:
+    - DUS-combined
+    - Huss

--- a/glambie/plot/plot_helpers.py
+++ b/glambie/plot/plot_helpers.py
@@ -100,7 +100,7 @@ def apply_vertical_adjustment_for_cumulative_plot(timeseries_to_adjust: pd.DataF
 
         # read adjustment at specific date
         row = reference_timeseries[reference_timeseries.dates == adjustment_date]
-        if len(row) >= 1:
+        if len(row) == 1:
             adjustment = row.iloc[0].changes
         # else need to upsample reference timeseries to monthly changes
         else:
@@ -109,6 +109,8 @@ def apply_vertical_adjustment_for_cumulative_plot(timeseries_to_adjust: pd.DataF
                                         np.array(reference_timeseries.changes),
                                         monthly_grid)
             ts_new = pd.DataFrame({"dates": monthly_grid, "changes": changes})
+            # handle Nan values, e.g. when there is a gap in the timeseries
+            ts_new = ts_new.fillna(method="bfill")
             adjustment = ts_new[ts_new.dates == adjustment_date].iloc[0].changes
     else:
         # this means we adjust the adjustment series at the first date of the reference series

--- a/glambie/plot/processing_plots.py
+++ b/glambie/plot/processing_plots.py
@@ -338,7 +338,7 @@ def plot_combination_of_sources_within_region(catalogue_results: DataCatalogue,
     for count, df in enumerate(catalogue_results.datasets):
         plot_non_cumulative_timeseries_on_axis(
             result_dataframe=df.data.as_dataframe(), ax=axes[0], colour=colours[count],
-            label="{}".format(df.data_group.long_name))
+            label="{}".format(df.data_group.long_name), plot_errors=plot_errors)
 
     # plot non-cumulative combined solution
     plot_non_cumulative_timeseries_on_axis(result_dataframe=combined_timeseries.data.as_dataframe(),

--- a/glambie/plot/processing_plots.py
+++ b/glambie/plot/processing_plots.py
@@ -5,7 +5,7 @@ from glambie.data.timeseries import Timeseries
 from glambie.const.data_groups import GlambieDataGroup
 from glambie.const.regions import RGIRegion
 from glambie.processing.path_handling import OutputPathHandler
-from glambie.processing.processing_helpers import convert_datasets_to_monthly_grid
+from glambie.processing.processing_helpers import convert_datasets_to_monthly_grid, get_reduced_catalogue_to_date_window
 from glambie.processing.processing_helpers import convert_datasets_to_unit_mwe
 from glambie.plot.plot_helpers import get_colours, add_labels_axlines_and_title, finalise_save_to_file_and_close_plot
 from glambie.plot.plot_helpers import plot_non_cumulative_timeseries_on_axis, plot_cumulative_timeseries_on_axis
@@ -21,8 +21,9 @@ def plot_all_plots_for_region_data_group_processing(output_path_handler: OutputP
                                                     timeseries_annual_combined: Timeseries,
                                                     data_catalogue_trends_homogenized: DataCatalogue,
                                                     data_catalogue_calibrated_series: DataCatalogue,
-                                                    timeseries_trend_combined: Timeseries
-                                                    ):
+                                                    timeseries_trend_combined: Timeseries,
+                                                    min_date: float,
+                                                    max_date: float):
     plot_fp = output_path_handler.get_plot_output_file_path(region=region, data_group=data_group,
                                                             plot_file_name="1_annual_input_data.png")
     # if not all datasets are the same unit they need to be converted to mwe for plotting
@@ -31,6 +32,18 @@ def plot_all_plots_for_region_data_group_processing(output_path_handler: OutputP
         data_catalogue_annual_raw = convert_datasets_to_unit_mwe(data_catalogue_annual_raw)
     if not data_catalogue_trends_raw.datasets_are_same_unit():  # trends
         data_catalogue_trends_raw = convert_datasets_to_unit_mwe(data_catalogue_trends_raw)
+
+    # clip raw datasets to minimum and maximum, so that the plotting focuses on the desired period
+    data_catalogue_annual_raw = get_reduced_catalogue_to_date_window(
+        data_catalogue=data_catalogue_annual_raw, start_date=min_date, end_date=max_date)
+    data_catalogue_trends_raw = get_reduced_catalogue_to_date_window(
+        data_catalogue=data_catalogue_trends_raw, start_date=min_date, end_date=max_date)
+    data_catalogue_annual_homogenized = get_reduced_catalogue_to_date_window(
+        data_catalogue=data_catalogue_annual_homogenized, start_date=min_date, end_date=max_date)
+    data_catalogue_annual_anomalies = get_reduced_catalogue_to_date_window(
+        data_catalogue=data_catalogue_annual_anomalies, start_date=min_date, end_date=max_date)
+    timeseries_annual_combined = timeseries_annual_combined.reduce_to_date_window(
+        start_date=min_date, end_date=max_date)
 
     plot_raw_input_data_of_data_group(catalogue_raw=data_catalogue_annual_raw,
                                       trend_combined=timeseries_trend_combined,

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -125,14 +125,13 @@ def combine_within_one_region(catalogue_data_group_results: DataCatalogue,
         output_path = output_path_handler.get_plot_output_file_path(region=combined_ts.region,
                                                                     data_group=GLAMBIE_DATA_GROUPS["consensus"],
                                                                     plot_file_name="1_consensus_sources_mwe.png")
-        # plot without uncertainties
-        plot_combination_of_sources_within_region(
-            catalogue_results=catalogue_data_group_results, combined_timeseries=combined_ts,
-            region=combined_ts.region, output_filepath=output_path, plot_errors=False)
-        # plot with uncertainties
-        plot_combination_of_sources_within_region(
-            catalogue_results=catalogue_data_group_results, combined_timeseries=combined_ts, region=combined_ts.region,
-            output_filepath=output_path.replace("mwe", "mwe_unc"), plot_errors=True)
+        output_path_unc = output_path.replace("mwe", "mwe_unc")
+
+        for output_filepath, plot_errors in ((output_path, False), (output_path_unc, True)):
+            plot_combination_of_sources_within_region(
+                catalogue_results=catalogue_data_group_results, combined_timeseries=combined_ts,
+                region=combined_ts.region, output_filepath=output_filepath, plot_errors=plot_errors)
+
         # save csv
         combined_ts.save_data_as_csv(output_path_handler.get_csv_output_file_path(
             region=combined_ts.region, data_group=GLAMBIE_DATA_GROUPS["consensus"],
@@ -170,15 +169,13 @@ def convert_and_save_one_region_to_gigatonnes(
         output_path = output_path_handler.get_plot_output_file_path(
             region=combined_region_timeseries_gt.region, data_group=GLAMBIE_DATA_GROUPS["consensus"],
             plot_file_name="2_consensus_sources_gt.png")
-        # plot without uncertainties
-        plot_combination_of_sources_within_region(
-            catalogue_results=catalogue_data_group_results_gt, combined_timeseries=combined_region_timeseries_gt,
-            region=combined_region_timeseries_gt.region, output_filepath=output_path, plot_errors=False)
-        # plot with uncertainties
-        plot_combination_of_sources_within_region(
-            catalogue_results=catalogue_data_group_results_gt, combined_timeseries=combined_region_timeseries_gt,
-            region=combined_region_timeseries_gt.region, output_filepath=output_path.replace("gt", "gt_unc"),
-            plot_errors=True)
+        output_path_unc = output_path.replace("gt", "gt_unc")
+
+        for output_filepath, plot_errors in ((output_path, False), (output_path_unc, True)):
+            plot_combination_of_sources_within_region(
+                catalogue_results=catalogue_data_group_results, combined_timeseries=combined_region_timeseries_gt,
+                region=combined_region_timeseries_gt.region, output_filepath=output_filepath, plot_errors=plot_errors)
+
         # save csv
         combined_region_timeseries_gt.save_data_as_csv(output_path_handler.get_csv_output_file_path(
             region=combined_region_timeseries_gt.region, data_group=GLAMBIE_DATA_GROUPS["consensus"],

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -7,6 +7,7 @@ from glambie.const.data_groups import GlambieDataGroup, GLAMBIE_DATA_GROUPS
 from glambie.const.regions import REGIONS, RGIRegion
 from glambie.const.constants import YearType
 from glambie.processing.processing_helpers import convert_datasets_to_longterm_trends_in_unit_mwe
+from glambie.processing.processing_helpers import get_reduced_catalogue_to_date_window
 from glambie.processing.processing_helpers import convert_datasets_to_monthly_grid
 from glambie.processing.processing_helpers import recombine_split_timeseries_in_catalogue
 from glambie.processing.processing_helpers import convert_datasets_to_annual_trends, convert_datasets_to_unit_mwe
@@ -320,6 +321,15 @@ def _run_region_timeseries_one_source(
                                                        data_catalogue_calibrated_series=catalogue_calibrated_series,
                                                        timeseries_trend_combined=trend_combined)
         # plot
+        # remove any dates that are far off the config time period, so that the plotting focuses on that period
+        data_catalogue_annual_raw = get_reduced_catalogue_to_date_window(
+            data_catalogue=data_catalogue_annual_raw,
+            start_date=min_max_time_window_for_longterm_trends[0] - 3,
+            end_date=min_max_time_window_for_longterm_trends[1] + 3)
+        data_catalogue_trends_raw = get_reduced_catalogue_to_date_window(
+            data_catalogue=data_catalogue_trends_raw,
+            start_date=min_max_time_window_for_longterm_trends[0] - 3,
+            end_date=min_max_time_window_for_longterm_trends[1] + 3)
         plot_all_plots_for_region_data_group_processing(output_path_handler=output_path_handler,
                                                         region=region,
                                                         data_group=data_group,

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -59,7 +59,6 @@ def run_one_region(glambie_run_config: GlambieRunConfig,
     # TODO: add annual backup dataset to config?
     annual_backup_dataset = season_calibration_dataset.copy()
 
-    # TODO: convert to RGIv6 if not already done
     result_datasets = []
     for data_group in glambie_run_config.datagroups_to_calculate:
         log.info('Starting to process region=%s datagroup=%s', region_config.region_name, data_group.name)

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -7,7 +7,6 @@ from glambie.const.data_groups import GlambieDataGroup, GLAMBIE_DATA_GROUPS
 from glambie.const.regions import REGIONS, RGIRegion
 from glambie.const.constants import YearType
 from glambie.processing.processing_helpers import convert_datasets_to_longterm_trends_in_unit_mwe
-from glambie.processing.processing_helpers import get_reduced_catalogue_to_date_window
 from glambie.processing.processing_helpers import convert_datasets_to_monthly_grid
 from glambie.processing.processing_helpers import recombine_split_timeseries_in_catalogue
 from glambie.processing.processing_helpers import convert_datasets_to_annual_trends, convert_datasets_to_unit_mwe
@@ -309,36 +308,31 @@ def _run_region_timeseries_one_source(
                 data_catalogue_trends_raw, split_dataset_names_trends)
 
         # save CSVs
-        save_all_csvs_for_region_data_group_processing(output_path_handler=output_path_handler,
-                                                       region=region,
-                                                       data_group=data_group,
-                                                       data_catalogue_annual_raw=data_catalogue_annual_raw,
-                                                       data_catalogue_trends_raw=data_catalogue_trends_raw,
-                                                       data_catalogue_annual_homogenized=data_catalogue_annual,
-                                                       data_catalogue_annual_anomalies=catalogue_annual_anomalies,
-                                                       timeseries_annual_combined=annual_combined,
-                                                       data_catalogue_trends_homogenized=data_catalogue_trends,
-                                                       data_catalogue_calibrated_series=catalogue_calibrated_series,
-                                                       timeseries_trend_combined=trend_combined)
+        save_all_csvs_for_region_data_group_processing(
+            output_path_handler=output_path_handler,
+            region=region,
+            data_group=data_group,
+            data_catalogue_annual_raw=data_catalogue_annual_raw,
+            data_catalogue_trends_raw=data_catalogue_trends_raw,
+            data_catalogue_annual_homogenized=data_catalogue_annual,
+            data_catalogue_annual_anomalies=catalogue_annual_anomalies,
+            timeseries_annual_combined=annual_combined,
+            data_catalogue_trends_homogenized=data_catalogue_trends,
+            data_catalogue_calibrated_series=catalogue_calibrated_series,
+            timeseries_trend_combined=trend_combined)
         # plot
-        # remove any dates that are far off the config time period, so that the plotting focuses on that period
-        data_catalogue_annual_raw = get_reduced_catalogue_to_date_window(
-            data_catalogue=data_catalogue_annual_raw,
-            start_date=min_max_time_window_for_longterm_trends[0] - 3,
-            end_date=min_max_time_window_for_longterm_trends[1] + 3)
-        data_catalogue_trends_raw = get_reduced_catalogue_to_date_window(
-            data_catalogue=data_catalogue_trends_raw,
-            start_date=min_max_time_window_for_longterm_trends[0] - 3,
-            end_date=min_max_time_window_for_longterm_trends[1] + 3)
-        plot_all_plots_for_region_data_group_processing(output_path_handler=output_path_handler,
-                                                        region=region,
-                                                        data_group=data_group,
-                                                        data_catalogue_annual_raw=data_catalogue_annual_raw,
-                                                        data_catalogue_trends_raw=data_catalogue_trends_raw,
-                                                        data_catalogue_annual_homogenized=data_catalogue_annual,
-                                                        data_catalogue_annual_anomalies=catalogue_annual_anomalies,
-                                                        timeseries_annual_combined=annual_combined,
-                                                        data_catalogue_trends_homogenized=data_catalogue_trends,
-                                                        data_catalogue_calibrated_series=catalogue_calibrated_series,
-                                                        timeseries_trend_combined=trend_combined)
+        plot_all_plots_for_region_data_group_processing(
+            output_path_handler=output_path_handler,
+            region=region,
+            data_group=data_group,
+            data_catalogue_annual_raw=data_catalogue_annual_raw,
+            data_catalogue_trends_raw=data_catalogue_trends_raw,
+            data_catalogue_annual_homogenized=data_catalogue_annual,
+            data_catalogue_annual_anomalies=catalogue_annual_anomalies,
+            timeseries_annual_combined=annual_combined,
+            data_catalogue_trends_homogenized=data_catalogue_trends,
+            data_catalogue_calibrated_series=catalogue_calibrated_series,
+            timeseries_trend_combined=trend_combined,
+            min_date=min_max_time_window_for_longterm_trends[0] - 1,
+            max_date=min_max_time_window_for_longterm_trends[1] + 1)
     return trend_combined

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -126,10 +126,14 @@ def combine_within_one_region(catalogue_data_group_results: DataCatalogue,
         output_path = output_path_handler.get_plot_output_file_path(region=combined_ts.region,
                                                                     data_group=GLAMBIE_DATA_GROUPS["consensus"],
                                                                     plot_file_name="1_consensus_sources_mwe.png")
-        # plot
-        plot_combination_of_sources_within_region(catalogue_results=catalogue_data_group_results,
-                                                  combined_timeseries=combined_ts, region=combined_ts.region,
-                                                  output_filepath=output_path)
+        # plot without uncertainties
+        plot_combination_of_sources_within_region(
+            catalogue_results=catalogue_data_group_results, combined_timeseries=combined_ts,
+            region=combined_ts.region, output_filepath=output_path, plot_errors=False)
+        # plot with uncertainties
+        plot_combination_of_sources_within_region(
+            catalogue_results=catalogue_data_group_results, combined_timeseries=combined_ts, region=combined_ts.region,
+            output_filepath=output_path.replace("mwe", "mwe_unc"), plot_errors=True)
         # save csv
         combined_ts.save_data_as_csv(output_path_handler.get_csv_output_file_path(
             region=combined_ts.region, data_group=GLAMBIE_DATA_GROUPS["consensus"],
@@ -164,14 +168,18 @@ def convert_and_save_one_region_to_gigatonnes(
     catalogue_data_group_results_gt = convert_datasets_to_unit_gt(catalogue_data_group_results)
 
     if output_path_handler is not None:
-        output_path = output_path_handler.get_plot_output_file_path(region=combined_region_timeseries_gt.region,
-                                                                    data_group=GLAMBIE_DATA_GROUPS["consensus"],
-                                                                    plot_file_name="2_consensus_sources_gt.png")
-        # plot
-        plot_combination_of_sources_within_region(catalogue_results=catalogue_data_group_results_gt,
-                                                  combined_timeseries=combined_region_timeseries_gt,
-                                                  region=combined_region_timeseries_gt.region,
-                                                  output_filepath=output_path)
+        output_path = output_path_handler.get_plot_output_file_path(
+            region=combined_region_timeseries_gt.region, data_group=GLAMBIE_DATA_GROUPS["consensus"],
+            plot_file_name="2_consensus_sources_gt.png")
+        # plot without uncertainties
+        plot_combination_of_sources_within_region(
+            catalogue_results=catalogue_data_group_results_gt, combined_timeseries=combined_region_timeseries_gt,
+            region=combined_region_timeseries_gt.region, output_filepath=output_path, plot_errors=False)
+        # plot with uncertainties
+        plot_combination_of_sources_within_region(
+            catalogue_results=catalogue_data_group_results_gt, combined_timeseries=combined_region_timeseries_gt,
+            region=combined_region_timeseries_gt.region, output_filepath=output_path.replace("gt", "gt_unc"),
+            plot_errors=True)
         # save csv
         combined_region_timeseries_gt.save_data_as_csv(output_path_handler.get_csv_output_file_path(
             region=combined_region_timeseries_gt.region, data_group=GLAMBIE_DATA_GROUPS["consensus"],

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -290,7 +290,8 @@ def extend_annual_timeseries_if_outside_trends_period(annual_timeseries: Timeser
     annual_timeseries_copy = annual_timeseries.copy()
     for ds in data_catalogue_trends.datasets:
         if (min(ds.data.start_dates) < min(annual_timeseries_copy.data.start_dates)) \
-                or (max(ds.data.end_dates) > max(annual_timeseries_copy.data.end_dates)):
+                or (max(ds.data.end_dates) > max(annual_timeseries_copy.data.end_dates)) \
+                or not annual_timeseries_copy.data.is_cumulative_valid():  # or the case where the timeseries has a gap
             log.info("Extension of annual is performed, as the trends are longer than the annual timeseries")
 
             # Remove trend of timeseries for extension over the common time period

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -17,7 +17,10 @@ def filter_catalogue_with_config_settings(data_group: GlambieDataGroup,
                                           region_config: RegionRunConfig,
                                           data_catalogue: DataCatalogue) -> Tuple[DataCatalogue, DataCatalogue]:
     """
-    Filters data catalogue by the "exclude_trend_datasets" and "exclude_annual_datasets" config settings
+    Filters data catalogue by the 'exclude_trend_datasets' and 'exclude_annual_datasets' config settings
+
+    Adds combined datasets to other data groups via the 'include_combined_trend_datasets' and
+    'include_combined_trend_datasets' config settings
 
     Parameters
     ----------

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -104,10 +104,14 @@ def filter_catalogue_with_config_settings(data_group: GlambieDataGroup,
     for ds in additional_annual_datasets:
         ds.user_group = ds.user_group + "_*"
     for ds in additional_trend_datasets:
-        ds.user_group = ds.user_group + "_*"
+        if ds not in additional_annual_datasets:
+            ds.user_group = ds.user_group + "_*"
 
     datasets_annual.extend(additional_annual_datasets)
     datasets_trend.extend(additional_trend_datasets)
+    log.info('Including the following combined datasets to ANNUAL calculations: datasets=%s',
+             additional_annual_datasets)
+    log.info('Including the following combined datasets to TREND calculations: datasets=%s', additional_trend_datasets)
 
     data_catalogue_annual = DataCatalogue.from_list(datasets_annual, base_path=data_catalogue.base_path)
     data_catalogue_trend = DataCatalogue.from_list(datasets_trend, base_path=data_catalogue.base_path)

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -62,16 +62,17 @@ def filter_catalogue_with_config_settings(data_group: GlambieDataGroup,
     if data_group == GLAMBIE_DATA_GROUPS["demdiff_and_glaciological"]:
         datasets_annual = [d for d in datasets_annual if d.data_group != GLAMBIE_DATA_GROUPS["demdiff"]]
     # 2.1 add combined datasets
-    include_combined_annual_datasets = region_config.region_run_settings[data_group.name].get(
-        "include_combined_annual_datasets", [])
-    include_combined_annual_datasets = [x for x in include_combined_annual_datasets if x is not None]
-    for ds in include_combined_annual_datasets:
-        catalogue_filtered = data_catalogue_original.get_filtered_catalogue(
-            data_group="combined", region_name=region_config.region_name, user_group=ds)
-        if len(catalogue_filtered.datasets) > 0:
-            datasets_annual.append(catalogue_filtered.datasets[0])
-        else:
-            log.info("Cannot find and add the following combined dataset to annual datasets: %s", ds)
+    if "include_combined_annual_datasets" in region_config.region_run_settings[data_group.name]:
+        include_combined_annual_datasets = region_config.region_run_settings[data_group.name].get(
+            "include_combined_annual_datasets", [])
+        include_combined_annual_datasets = [x for x in include_combined_annual_datasets if x is not None]
+        for ds in include_combined_annual_datasets:
+            catalogue_filtered = data_catalogue_original.get_filtered_catalogue(
+                data_group="combined", region_name=region_config.region_name, user_group=ds)
+            if len(catalogue_filtered.datasets) > 0:
+                datasets_annual.append(catalogue_filtered.datasets[0])
+            else:
+                log.info("Cannot find and add the following combined dataset to annual datasets: %s", ds)
 
     # 3 filter out what has been specified in config for longterm trend datasets
     datasets_trend = data_catalogue.datasets.copy()
@@ -83,16 +84,17 @@ def filter_catalogue_with_config_settings(data_group: GlambieDataGroup,
     if data_group == GLAMBIE_DATA_GROUPS["demdiff_and_glaciological"]:
         datasets_trend = [d for d in datasets_trend if d.data_group != GLAMBIE_DATA_GROUPS["glaciological"]]
     # 3.1 add combined trend datasets
-    include_combined_trend_datasets = region_config.region_run_settings[data_group.name].get(
-        "include_combined_trend_datasets", [])
-    include_combined_trend_datasets = [x for x in include_combined_trend_datasets if x is not None]
-    for ds in include_combined_trend_datasets:
-        catalogue_filtered = data_catalogue_original.get_filtered_catalogue(
-            data_group="combined", region_name=region_config.region_name, user_group=ds)
-        if len(catalogue_filtered.datasets) > 0:
-            datasets_trend.append(catalogue_filtered.datasets[0])
-        else:
-            log.info("Cannot find and add the following combined dataset to trend datasets: %s", ds)
+    if "include_combined_trend_datasets" in region_config.region_run_settings[data_group.name]:
+        include_combined_trend_datasets = region_config.region_run_settings[data_group.name].get(
+            "include_combined_trend_datasets", [])
+        include_combined_trend_datasets = [x for x in include_combined_trend_datasets if x is not None]
+        for ds in include_combined_trend_datasets:
+            catalogue_filtered = data_catalogue_original.get_filtered_catalogue(
+                data_group="combined", region_name=region_config.region_name, user_group=ds)
+            if len(catalogue_filtered.datasets) > 0:
+                datasets_trend.append(catalogue_filtered.datasets[0])
+            else:
+                log.info("Cannot find and add the following combined dataset to trend datasets: %s", ds)
 
     data_catalogue_annual = DataCatalogue.from_list(datasets_annual, base_path=data_catalogue.base_path)
     data_catalogue_trend = DataCatalogue.from_list(datasets_trend, base_path=data_catalogue.base_path)

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -70,7 +70,9 @@ def filter_catalogue_with_config_settings(data_group: GlambieDataGroup,
             catalogue_filtered = data_catalogue_original.get_filtered_catalogue(
                 data_group="combined", region_name=region_config.region_name, user_group=ds)
             if len(catalogue_filtered.datasets) > 0:
-                datasets_annual.append(catalogue_filtered.datasets[0])
+                ds = catalogue_filtered.datasets[0]
+                ds.user_group = ds.user_group + "_*"
+                datasets_annual.append(ds)
             else:
                 log.info("Cannot find and add the following combined dataset to annual datasets: %s", ds)
 
@@ -92,7 +94,9 @@ def filter_catalogue_with_config_settings(data_group: GlambieDataGroup,
             catalogue_filtered = data_catalogue_original.get_filtered_catalogue(
                 data_group="combined", region_name=region_config.region_name, user_group=ds)
             if len(catalogue_filtered.datasets) > 0:
-                datasets_trend.append(catalogue_filtered.datasets[0])
+                ds = catalogue_filtered.datasets[0]
+                ds.user_group = ds.user_group + "_*"
+                datasets_trend.append(ds)
             else:
                 log.info("Cannot find and add the following combined dataset to trend datasets: %s", ds)
 

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -74,7 +74,7 @@ def filter_catalogue_with_config_settings(data_group: GlambieDataGroup,
     if data_group == GLAMBIE_DATA_GROUPS["demdiff_and_glaciological"]:
         datasets_trend = [d for d in datasets_trend if d.data_group != GLAMBIE_DATA_GROUPS["glaciological"]]
 
-    # 4 add combined trend datasets
+    # 4 add additional combined datasets stated in configs to data group
     additional_annual_datasets = get_additional_combined_datasets(
         data_catalogue=data_catalogue_original, data_group=data_group,
         region_config=region_config, type_of_information="annual")

--- a/tests/processing/test_processing_helpers.py
+++ b/tests/processing/test_processing_helpers.py
@@ -151,7 +151,8 @@ def test_filter_catalogue_with_config_settings_demdiff_and_glaciological(example
     assert any(d.user_group == "sloths" for d in datasets_trend.datasets)
 
 
-def test_filter_catalogue_with_config_settings_with_added_combined_dataset_to_annual(example_catalogue_2, glambie_config):
+def test_filter_catalogue_with_config_settings_with_added_combined_dataset_to_annual(
+        example_catalogue_2, glambie_config):
     data_group = GLAMBIE_DATA_GROUPS["demdiff_and_glaciological"]
     data_catalogue = example_catalogue_2
     region_config = glambie_config.regions[1]
@@ -170,7 +171,8 @@ def test_filter_catalogue_with_config_settings_with_added_combined_dataset_to_an
     assert not any(d.user_group == "hello_kitty" for d in datasets_trend.datasets)
 
 
-def test_filter_catalogue_with_config_settings_with_added_combined_dataset_to_trends(example_catalogue_2, glambie_config):
+def test_filter_catalogue_with_config_settings_with_added_combined_dataset_to_trends(
+        example_catalogue_2, glambie_config):
     data_group = GLAMBIE_DATA_GROUPS["demdiff_and_glaciological"]
     data_catalogue = example_catalogue_2
     region_config = glambie_config.regions[1]

--- a/tests/processing/test_processing_helpers.py
+++ b/tests/processing/test_processing_helpers.py
@@ -64,6 +64,13 @@ def example_catalogue_2():
             "user_group": "dolphins",
             "data_group": "glaciological",
             "unit": "mwe"
+        },
+        {
+            "filename": "xx.csv",
+            "region": "svalbard",
+            "user_group": "hello_kitty",
+            "data_group": "combined",
+            "unit": "mwe"
         }]})
 
 
@@ -142,6 +149,42 @@ def test_filter_catalogue_with_config_settings_demdiff_and_glaciological(example
     assert all(d.user_group != "sharks" for d in datasets_trend.datasets)
     assert all(d.data_group != GLAMBIE_DATA_GROUPS["glaciological"] for d in datasets_trend.datasets)
     assert any(d.user_group == "sloths" for d in datasets_trend.datasets)
+
+
+def test_filter_catalogue_with_config_settings_with_added_combined_dataset_to_annual(example_catalogue_2, glambie_config):
+    data_group = GLAMBIE_DATA_GROUPS["demdiff_and_glaciological"]
+    data_catalogue = example_catalogue_2
+    region_config = glambie_config.regions[1]
+    # include a combined dataset
+    region_config.region_run_settings[data_group.name]["include_combined_annual_datasets"] = ["hello_kitty"]
+
+    datasets_annual, datasets_trend = filter_catalogue_with_config_settings(
+        data_group=data_group, region_config=region_config, data_catalogue=data_catalogue)
+
+    # length of annual datasets should be 2, with the combined added
+    assert len(datasets_annual.datasets) == 2
+    # hello_kitty should have been added to annual datasets
+    assert any(d.user_group == "hello_kitty" for d in datasets_annual.datasets)
+    assert not all(d.data_group == GLAMBIE_DATA_GROUPS["glaciological"] for d in datasets_annual.datasets)
+    # hello_kitty should not have been added to trend datasets
+    assert not any(d.user_group == "hello_kitty" for d in datasets_trend.datasets)
+
+
+def test_filter_catalogue_with_config_settings_with_added_combined_dataset_to_trends(example_catalogue_2, glambie_config):
+    data_group = GLAMBIE_DATA_GROUPS["demdiff_and_glaciological"]
+    data_catalogue = example_catalogue_2
+    region_config = glambie_config.regions[1]
+    # include a combined dataset
+    region_config.region_run_settings[data_group.name]["include_combined_trend_datasets"] = ["hello_kitty"]
+
+    datasets_annual, datasets_trend = filter_catalogue_with_config_settings(
+        data_group=data_group, region_config=region_config, data_catalogue=data_catalogue)
+
+    # hello_kitty should have been added to trend datasets
+    assert any(d.user_group == "hello_kitty" for d in datasets_trend.datasets)
+    assert not all(d.data_group == GLAMBIE_DATA_GROUPS["glaciological"] for d in datasets_trend.datasets)
+    # hello_kitty should not have been added to annual datasets
+    assert not any(d.user_group == "hello_kitty" for d in datasets_annual.datasets)
 
 
 def test_slice_timeseries_at_gaps():

--- a/tests/processing/test_processing_helpers.py
+++ b/tests/processing/test_processing_helpers.py
@@ -164,11 +164,11 @@ def test_filter_catalogue_with_config_settings_with_added_combined_dataset_to_an
 
     # length of annual datasets should be 2, with the combined added
     assert len(datasets_annual.datasets) == 2
-    # hello_kitty should have been added to annual datasets
-    assert any(d.user_group == "hello_kitty" for d in datasets_annual.datasets)
+    # hello_kitty should have been added to annual datasets; with an asterix added
+    assert any(d.user_group == "hello_kitty_*" for d in datasets_annual.datasets)
     assert not all(d.data_group == GLAMBIE_DATA_GROUPS["glaciological"] for d in datasets_annual.datasets)
-    # hello_kitty should not have been added to trend datasets
-    assert not any(d.user_group == "hello_kitty" for d in datasets_trend.datasets)
+    # hello_kitty should not have been added to trend datasets; with an asterix added
+    assert not any(d.user_group == "hello_kitty_*" for d in datasets_trend.datasets)
 
 
 def test_filter_catalogue_with_config_settings_with_added_combined_dataset_to_trends(
@@ -182,11 +182,11 @@ def test_filter_catalogue_with_config_settings_with_added_combined_dataset_to_tr
     datasets_annual, datasets_trend = filter_catalogue_with_config_settings(
         data_group=data_group, region_config=region_config, data_catalogue=data_catalogue)
 
-    # hello_kitty should have been added to trend datasets
-    assert any(d.user_group == "hello_kitty" for d in datasets_trend.datasets)
+    # hello_kitty should have been added to trend datasets; with an asterix added
+    assert any(d.user_group == "hello_kitty_*" for d in datasets_trend.datasets)
     assert not all(d.data_group == GLAMBIE_DATA_GROUPS["glaciological"] for d in datasets_trend.datasets)
-    # hello_kitty should not have been added to annual datasets
-    assert not any(d.user_group == "hello_kitty" for d in datasets_annual.datasets)
+    # hello_kitty should not have been added to annual datasets; with an asterix added
+    assert not any(d.user_group == "hello_kitty_*" for d in datasets_annual.datasets)
 
 
 def test_slice_timeseries_at_gaps():

--- a/tests/test_data/configs/test_config_iceland.yaml
+++ b/tests/test_data/configs/test_config_iceland.yaml
@@ -9,17 +9,29 @@ seasonal_correction_dataset:
 
 region_run_settings:
   altimetry:
-    exclude_annual_datasets :
-      - xxxxxxxxxxxxxxxxxxxx
-    exclude_trend_datasets :
-      - xxxxxxxxxxxxxxxxxxxx
+    exclude_annual_datasets:
+      - 
+    exclude_trend_datasets:
+      - 
+    include_combined_annual_datasets:
+      -
+    include_combined_trend_datasets:
+      -
   gravimetry:
-    exclude_annual_datasets :
+    exclude_annual_datasets:
     - ciraci
-    exclude_trend_datasets :
+    exclude_trend_datasets:
     - wouters
+    include_combined_annual_datasets:
+      -
+    include_combined_trend_datasets:
+      -
   demdiff_and_glaciological:
-    exclude_annual_datasets : # glaciological datasets
+    exclude_annual_datasets: # glaciological datasets
     - sharks
-    exclude_trend_datasets : # demdiff datasets
+    exclude_trend_datasets: # demdiff datasets
     - hugonnet
+    include_combined_annual_datasets:
+      -
+    include_combined_trend_datasets:
+      -

--- a/tests/test_data/configs/test_config_svalbard.yaml
+++ b/tests/test_data/configs/test_config_svalbard.yaml
@@ -9,17 +9,29 @@ seasonal_correction_dataset:
 
 region_run_settings:
   altimetry:
-    exclude_annual_datasets :
+    exclude_annual_datasets:
       - lions
-    exclude_trend_datasets :
+    exclude_trend_datasets:
       - sharks
+    include_combined_annual_datasets:
+      -
+    include_combined_trend_datasets:
+      -
   gravimetry:
-    exclude_annual_datasets :
+    exclude_annual_datasets:
     - ciraci
-    exclude_trend_datasets :
+    exclude_trend_datasets:
     - wouters
+    include_combined_annual_datasets:
+      - random
+    include_combined_trend_datasets:
+      -
   demdiff_and_glaciological:
-    exclude_annual_datasets : # glaciological datasets
+    exclude_annual_datasets: # glaciological datasets
     - lions
-    exclude_trend_datasets : # demdiff datasets
+    exclude_trend_datasets: # demdiff datasets
     - sharks
+    include_combined_annual_datasets:
+      - 
+    include_combined_trend_datasets:
+      -


### PR DESCRIPTION
Functionality to add datasets from the category "combined" to the other data source categories.
It's not a chunky PR, just a lot of config changes as part of it:)

The idea here is that combined datasets can be attributed to the category they fit most in (e.g. altimetry or gravimetry). Therefore the config files now accept the keywords "include_combined_annual_datasets" and "include_combined_trend_datasets" (both optional), where combined datasets can be listed to be added to that category as an exception.

Part of the PR is also the now updated config files with the combined datasets assigned to different categories to be discussed in the workshop

This change has prompted several smaller changes such as:
- restrict min-max of datasets for nicer plotting
- quick handle of gaps when extending annual series
- handle cumulative plotting in the case where reference timeseries for vertical adjustment has gaps
