### PR TITLE
GRACE gap handling

### DIFF
--- a/configuration/10_north_asia.yaml
+++ b/configuration/10_north_asia.yaml
@@ -17,9 +17,11 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/11_central_europe.yaml
+++ b/configuration/11_central_europe.yaml
@@ -17,9 +17,11 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/12_caucasus_middle_east.yaml
+++ b/configuration/12_caucasus_middle_east.yaml
@@ -17,9 +17,11 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - Wouters
+    - Sasgen_AWIarc_RL01.1
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - Wouters
+    - Sasgen_AWIarc_RL01.1
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/13_central_asia.yaml
+++ b/configuration/13_central_asia.yaml
@@ -16,12 +16,16 @@ region_run_settings:
     - Treichler_ICESat
     - Treichler_snowfall
     exclude_trend_datasets :
-    - 
+    - Treichler_ICESat
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Harig_Group
+    - Wouters
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Harig_Group
+    - Wouters
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave
@@ -34,4 +38,3 @@ region_run_settings:
     include_combined_trend_datasets:
     - DUS-combined
     - Huss
-    - Miles2021

--- a/configuration/14_south_asia_west.yaml
+++ b/configuration/14_south_asia_west.yaml
@@ -16,12 +16,14 @@ region_run_settings:
     - Treichler_ICESat
     - Treichler_snowfall
     exclude_trend_datasets :
-    - 
+    - Treichler_ICESat
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - Wouters
+    - Sasgen_AWIarc_RL01.1
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - Wouters
+    - Sasgen_AWIarc_RL01.1
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave
@@ -34,4 +36,3 @@ region_run_settings:
     include_combined_trend_datasets:
     - DUS-combined
     - Huss
-    - Miles2021

--- a/configuration/15_south_asia_east.yaml
+++ b/configuration/15_south_asia_east.yaml
@@ -16,12 +16,14 @@ region_run_settings:
     - Treichler_ICESat
     - Treichler_snowfall
     exclude_trend_datasets :
-    - 
+    - Treichler_ICESat
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave
@@ -34,4 +36,3 @@ region_run_settings:
     include_combined_trend_datasets:
     - DUS-combined
     - Huss
-    - Miles2021

--- a/configuration/16_low_latitudes.yaml
+++ b/configuration/16_low_latitudes.yaml
@@ -17,9 +17,11 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/17_southern_andes.yaml
+++ b/configuration/17_southern_andes.yaml
@@ -17,9 +17,9 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - Harig_Group
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - Harig_Group
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/18_new_zealand.yaml
+++ b/configuration/18_new_zealand.yaml
@@ -17,9 +17,13 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
+    - Harig_Group
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
+    - Harig_Group
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/19_antarctic_and_subantarctic.yaml
+++ b/configuration/19_antarctic_and_subantarctic.yaml
@@ -12,7 +12,7 @@ seasonal_correction_dataset:
 region_run_settings:
   altimetry:
     exclude_annual_datasets :
-    - 
+    - Khan
     exclude_trend_datasets :
     - 
   gravimetry:

--- a/configuration/19_antarctic_and_subantarctic.yaml
+++ b/configuration/19_antarctic_and_subantarctic.yaml
@@ -13,6 +13,7 @@ region_run_settings:
   altimetry:
     exclude_annual_datasets :
     - Khan
+    - Gardner2013_icesat
     exclude_trend_datasets :
     - 
   gravimetry:

--- a/configuration/1_alaska.yaml
+++ b/configuration/1_alaska.yaml
@@ -17,9 +17,9 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - 
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - 
     include_combined_trend_datasets:
     - ArcticInSituvGRACE
   demdiff_and_glaciological :

--- a/configuration/1_alaska.yaml
+++ b/configuration/1_alaska.yaml
@@ -21,7 +21,7 @@ region_run_settings:
     exclude_trend_datasets :
     - 
     include_combined_trend_datasets:
-    - ArcticInSituvGRACE
+    - Box2018
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/2_western_canada_us.yaml
+++ b/configuration/2_western_canada_us.yaml
@@ -15,16 +15,21 @@ region_run_settings:
     - Menounos_WNA_alt1
     - Menounos_WNA_is2gedi
     exclude_trend_datasets :
-    - 
+    -
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - Harig_Group
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - Harig_Group
+    - Sasgen_AWIarc_RL01.1
+    - Wouters
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave
     - WGMS-mean_ba
+    - Menounos_WNA_glac
     exclude_trend_datasets : # demdiff datasets
     - 
     include_combined_annual_datasets:

--- a/configuration/3_arctic_canada_north.yaml
+++ b/configuration/3_arctic_canada_north.yaml
@@ -13,19 +13,14 @@ region_run_settings:
   altimetry:
     exclude_annual_datasets :
     - Tepes
+    - Khan
     exclude_trend_datasets :
     - 
-    include_combined_trend_datasets:
-    - Colgan2015
   gravimetry:
     exclude_annual_datasets :
-    - LEGOS-MAGELLIUM_gap
-    - LEGOS-MAG-bis_gap
-    - Sasgen_AWIarc_gap
+    - 
     exclude_trend_datasets :
-    - LEGOS-MAGELLIUM_gap
-    - LEGOS-MAG-bis_gap
-    - Sasgen_AWIarc_gap
+    - 
     include_combined_trend_datasets:
     - ArcticInSituvGRACE
     - Colgan2015

--- a/configuration/3_arctic_canada_north.yaml
+++ b/configuration/3_arctic_canada_north.yaml
@@ -14,6 +14,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Tepes
     - Khan
+    - Gardner2013_icesat
     exclude_trend_datasets :
     - 
   gravimetry:
@@ -22,7 +23,7 @@ region_run_settings:
     exclude_trend_datasets :
     - 
     include_combined_trend_datasets:
-    - ArcticInSituvGRACE
+    - Box2018
     - Colgan2015
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets

--- a/configuration/4_arctic_canada_south.yaml
+++ b/configuration/4_arctic_canada_south.yaml
@@ -13,19 +13,14 @@ region_run_settings:
   altimetry:
     exclude_annual_datasets :
     - Tepes
+    - Khan
     exclude_trend_datasets :
     - 
-    include_combined_trend_datasets:
-    - Colgan2015
   gravimetry:
     exclude_annual_datasets :
-    - LEGOS-MAGELLIUM_gap
-    - LEGOS-MAG-bis_gap
-    - Sasgen_AWIarc_gap
+    - 
     exclude_trend_datasets :
-    - LEGOS-MAGELLIUM_gap
-    - LEGOS-MAG-bis_gap
-    - Sasgen_AWIarc_gap
+    - 
     include_combined_trend_datasets:
     - ArcticInSituvGRACE
     - Colgan2015

--- a/configuration/4_arctic_canada_south.yaml
+++ b/configuration/4_arctic_canada_south.yaml
@@ -14,6 +14,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Tepes
     - Khan
+    - Gardner2013_icesat
     exclude_trend_datasets :
     - 
   gravimetry:
@@ -22,7 +23,7 @@ region_run_settings:
     exclude_trend_datasets :
     - 
     include_combined_trend_datasets:
-    - ArcticInSituvGRACE
+    - Box2018
     - Colgan2015
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets

--- a/configuration/5_greenland_periphery.yaml
+++ b/configuration/5_greenland_periphery.yaml
@@ -14,7 +14,7 @@ region_run_settings:
     exclude_annual_datasets :
     - Khan
     - Bolch_2013
-    - Nilsson_Gardner
+    - Gardner2013_icesat
     exclude_trend_datasets :
     - Nilsson_Gardner
   gravimetry:

--- a/configuration/5_greenland_periphery.yaml
+++ b/configuration/5_greenland_periphery.yaml
@@ -14,17 +14,14 @@ region_run_settings:
     exclude_annual_datasets :
     - Khan
     - Bolch_2013
+    - Nilsson_Gardner
     exclude_trend_datasets :
-    - 
-    include_combined_trend_datasets:
-    - Colgan2015
+    - Nilsson_Gardner
   gravimetry:
     exclude_annual_datasets :
     - 
     exclude_trend_datasets :
     - 
-    include_combined_trend_datasets:
-    - Colgan2015
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/6_iceland.yaml
+++ b/configuration/6_iceland.yaml
@@ -16,13 +16,9 @@ region_run_settings:
       - Tepes
   gravimetry:
     exclude_annual_datasets :
-    - LEGOS-MAGELLIUM_gap
-    - LEGOS-MAG-bis_gap
-    - Sasgen_AWIarc_gap
+    - 
     exclude_trend_datasets :
-    - LEGOS-MAGELLIUM_gap
-    - LEGOS-MAG-bis_gap
-    - Sasgen_AWIarc_gap
+    - 
     include_combined_trend_datasets:
     - ArcticInSituvGRACE
   demdiff_and_glaciological :
@@ -36,9 +32,7 @@ region_run_settings:
     - DUS-combined
     - Huss
     - Iceland-mb-group_tot
-    - Iceland-mb-group_smb
     include_combined_trend_datasets:
     - DUS-combined
     - Huss
     - Iceland-mb-group_tot
-    - Iceland-mb-group_smb

--- a/configuration/6_iceland.yaml
+++ b/configuration/6_iceland.yaml
@@ -20,7 +20,7 @@ region_run_settings:
     exclude_trend_datasets :
     - 
     include_combined_trend_datasets:
-    - ArcticInSituvGRACE
+    - Box2018
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/7_svalbard.yaml
+++ b/configuration/7_svalbard.yaml
@@ -17,13 +17,9 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - LEGOS-MAGELLIUM_gap
-    - LEGOS-MAG-bis_gap
-    - Sasgen_AWIarc_gap
+    - 
     exclude_trend_datasets :
-    - LEGOS-MAGELLIUM_gap
-    - LEGOS-MAG-bis_gap
-    - Sasgen_AWIarc_gap
+    - 
     include_combined_trend_datasets:
     - ArcticInSituvGRACE
   demdiff_and_glaciological :

--- a/configuration/7_svalbard.yaml
+++ b/configuration/7_svalbard.yaml
@@ -13,6 +13,7 @@ region_run_settings:
   altimetry:
     exclude_annual_datasets :
     - Tepes
+    - Gardner2013_icesat
     exclude_trend_datasets :
     - 
   gravimetry:
@@ -21,7 +22,7 @@ region_run_settings:
     exclude_trend_datasets :
     - 
     include_combined_trend_datasets:
-    - ArcticInSituvGRACE
+    - Box2018
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/8_scandinavia.yaml
+++ b/configuration/8_scandinavia.yaml
@@ -17,9 +17,9 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_gap
+    - 
     exclude_trend_datasets :
-    - Sasgen_AWIarc_gap
+    - 
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/configuration/9_russian_arctic.yaml
+++ b/configuration/9_russian_arctic.yaml
@@ -17,13 +17,9 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - LEGOS-MAGELLIUM_gap
-    - LEGOS-MAG-bis_gap
-    - Sasgen_AWIarc_gap
+    - 
     exclude_trend_datasets :
-    - LEGOS-MAGELLIUM_gap
-    - LEGOS-MAG-bis_gap
-    - Sasgen_AWIarc_gap
+    - 
     include_combined_trend_datasets:
     - ArcticInSituvGRACE
   demdiff_and_glaciological :

--- a/configuration/9_russian_arctic.yaml
+++ b/configuration/9_russian_arctic.yaml
@@ -13,6 +13,7 @@ region_run_settings:
   altimetry:
     exclude_annual_datasets :
     - Tepes
+    - Gardner2013_icesat
     exclude_trend_datasets :
     - 
   gravimetry:
@@ -21,7 +22,7 @@ region_run_settings:
     exclude_trend_datasets :
     - 
     include_combined_trend_datasets:
-    - ArcticInSituvGRACE
+    - Box2018
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/glambie/const/constants.py
+++ b/glambie/const/constants.py
@@ -11,3 +11,11 @@ OCEAN_AREA_IN_KM2 = 3.625e8  # Cogley et al. (2012)
 class YearType(Enum):
     GLACIOLOGICAL = "glaciological"
     CALENDAR = "calendar"
+
+
+class GraceGap(Enum):
+    """
+    A class describing the time gap between the two gravimetry missions (GRACE and GRACE-FO).
+    """
+    START_DATE = 2017.4
+    END_DATE = 2018.6

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -519,7 +519,7 @@ class Timeseries():
         object_copy.area_change_applied = apply_area_change  # store if has been applied or not
         return object_copy
 
-    def reduce_to_date_window(self, start_date: float, end_date: float) -> Timeseries:
+    def reduce_to_date_window(self, start_date: float, end_date: float, date_window_is_gap: bool = False) -> Timeseries:
         """
         Filter timeseries by start and end date
 
@@ -529,6 +529,11 @@ class Timeseries():
             decimal year of start date
         end_date : float
             decimal year of end date
+        date_window_is_gap : bool
+            If set to False, all values smaller than start date and larger than end date are removed.
+            If set to True the start and end date are taken as start and end of a gap that is removed from
+            the timeseries. This means that all values between start and end date are removed.
+            by default False
 
         Returns
         -------
@@ -537,7 +542,10 @@ class Timeseries():
         """
         object_copy = self.copy()
         df = object_copy.data.as_dataframe()
-        df = df[((df.end_dates <= end_date) & (df.start_dates >= start_date))].reset_index(drop=True)
+        if date_window_is_gap:  # remove values between start and end date
+            df = df[~((df.end_dates <= end_date) & (df.start_dates >= start_date))].reset_index(drop=True)
+        else:  # remove values smaller than start date or larger than end date
+            df = df[((df.end_dates <= end_date) & (df.start_dates >= start_date))].reset_index(drop=True)
         object_copy.data = TimeseriesData(start_dates=np.array(df["start_dates"]),
                                           end_dates=np.array(df["end_dates"]),
                                           changes=np.array(df["changes"]),

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -186,7 +186,7 @@ def convert_and_save_one_region_to_gigatonnes(
 
         for output_filepath, plot_errors in ((output_path, False), (output_path_unc, True)):
             plot_combination_of_sources_within_region(
-                catalogue_results=catalogue_data_group_results, combined_timeseries=combined_region_timeseries_gt,
+                catalogue_results=catalogue_data_group_results_gt, combined_timeseries=combined_region_timeseries_gt,
                 region=combined_region_timeseries_gt.region, output_filepath=output_filepath, plot_errors=plot_errors)
 
         # save csv

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -8,11 +8,12 @@ from glambie.const.regions import REGIONS, RGIRegion
 from glambie.data.data_catalogue import DataCatalogue, Timeseries
 from glambie.data.data_catalogue_helpers import calibrate_timeseries_with_trends_catalogue
 from glambie.plot.processing_plots import (
-plot_all_plots_for_region_data_group_processing, plot_combination_of_sources_within_region)
+    plot_all_plots_for_region_data_group_processing, plot_combination_of_sources_within_region)
 from glambie.processing.output_helpers import save_all_csvs_for_region_data_group_processing
 from glambie.processing.path_handling import OutputPathHandler
 from glambie.processing.processing_helpers import (
-check_and_handle_gaps_in_timeseries, convert_datasets_to_annual_trends, convert_datasets_to_longterm_trends_in_unit_mwe, convert_datasets_to_monthly_grid)
+    check_and_handle_gaps_in_timeseries, convert_datasets_to_annual_trends,
+    convert_datasets_to_longterm_trends_in_unit_mwe, convert_datasets_to_monthly_grid)
 from glambie.processing.processing_helpers import convert_datasets_to_unit_gt
 from glambie.processing.processing_helpers import convert_datasets_to_unit_mwe
 from glambie.processing.processing_helpers import extend_annual_timeseries_if_outside_trends_period

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -549,7 +549,8 @@ def set_unneeded_columns_to_nan(data_catalogue: DataCatalogue) -> DataCatalogue:
 
 def get_reduced_catalogue_to_date_window(data_catalogue: DataCatalogue,
                                          start_date: float,
-                                         end_date: float) -> DataCatalogue:
+                                         end_date: float,
+                                         date_window_is_gap: bool = False) -> DataCatalogue:
     """
     Reduces all datasets within a data catalogue to desired minimum and maximum dates
 
@@ -561,6 +562,11 @@ def get_reduced_catalogue_to_date_window(data_catalogue: DataCatalogue,
         desired start date of output datasets
     end_date : float
         desired end date of output datasets
+    date_window_is_gap : bool
+        If set to False, all values smaller than start date and larger than end date are removed.
+        If set to True the start and end date are taken as start and end of a gap that is removed from
+        the timeseries. This means that all values between start and end date are removed.
+        by default False
 
     Returns
     -------
@@ -569,5 +575,6 @@ def get_reduced_catalogue_to_date_window(data_catalogue: DataCatalogue,
     """
     reduced_datasets = []
     for dataset in data_catalogue.datasets:
-        reduced_datasets.append(dataset.reduce_to_date_window(start_date=start_date, end_date=end_date))
+        reduced_datasets.append(dataset.reduce_to_date_window(start_date=start_date, end_date=end_date,
+                                                              date_window_is_gap=date_window_is_gap))
     return DataCatalogue.from_list(reduced_datasets, base_path=data_catalogue.base_path)

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -74,7 +74,7 @@ def filter_catalogue_with_config_settings(data_group: GlambieDataGroup,
     if data_group == GLAMBIE_DATA_GROUPS["demdiff_and_glaciological"]:
         datasets_trend = [d for d in datasets_trend if d.data_group != GLAMBIE_DATA_GROUPS["glaciological"]]
 
-    # 4 add combined trend datasets
+    # 4 add additional combined datasets stated in configs to data group
     additional_annual_datasets = get_additional_combined_datasets(
         data_catalogue=data_catalogue_original, data_group=data_group,
         region_config=region_config, type_of_information="annual")

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -469,3 +469,16 @@ def test_reduce_to_date_window(example_timeseries_ingested):
     assert np.array_equal(reduced_timeseries.data.changes, example_timeseries_ingested.data.changes[1:])
     assert np.array_equal(reduced_timeseries.data.errors, example_timeseries_ingested.data.errors[1:])
     assert np.array_equal(reduced_timeseries.data.end_dates, example_timeseries_ingested.data.end_dates[1:])
+
+
+def test_reduce_to_date_window_with_gap(example_timeseries_ingested):
+    reduced_timeseries = example_timeseries_ingested.reduce_to_date_window(start_date=2010.0, end_date=2010.2,
+                                                                           date_window_is_gap=True)
+    assert np.array_equal(reduced_timeseries.data.changes, example_timeseries_ingested.data.changes[1:])
+    assert np.array_equal(reduced_timeseries.data.errors, example_timeseries_ingested.data.errors[1:])
+    assert np.array_equal(reduced_timeseries.data.start_dates, example_timeseries_ingested.data.start_dates[1:])
+    reduced_timeseries = example_timeseries_ingested.reduce_to_date_window(start_date=2010.2, end_date=2010.3,
+                                                                           date_window_is_gap=True)
+    assert np.array_equal(reduced_timeseries.data.changes, example_timeseries_ingested.data.changes[:-1])
+    assert np.array_equal(reduced_timeseries.data.errors, example_timeseries_ingested.data.errors[:-1])
+    assert np.array_equal(reduced_timeseries.data.end_dates, example_timeseries_ingested.data.end_dates[:-1])


### PR DESCRIPTION
Small PR to handle gravimetry gap:

The gap between 2017 and 2018 GRACE and GRACE=FO mission means that gravimetry datasets have less high temporal resolution over that period. Therefore we now remove the gap just for the variability calculation ("annual" catalogue).
The gap is not removed for trend datasets, as the long term trend is still valid with the gap.

In addition the default configs are updated according to newly submitted datasets and workshop decisions - nothing to review for that.