### PR TITLE
Replace no data in variability with consensus

### DIFF
--- a/configuration/18_new_zealand.yaml
+++ b/configuration/18_new_zealand.yaml
@@ -17,12 +17,12 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
-    - Sasgen_AWIarc_RL01.1
+    - Sasgen_AWIarc_RL01_2
     - Wouters
     - Harig_Group
     - Jacob_2012_dmdt
     exclude_trend_datasets :
-    - Sasgen_AWIarc_RL01.1
+    - Sasgen_AWIarc_RL01_2
     - Wouters
     - Harig_Group
     - Jacob_2012_dmdt

--- a/configuration/8_scandinavia.yaml
+++ b/configuration/8_scandinavia.yaml
@@ -17,9 +17,13 @@ region_run_settings:
     - 
   gravimetry:
     exclude_annual_datasets :
+    - Sasgen_AWIarc_RL01_2
+    - Wouters
     - Jacob_2012_dmdt
     exclude_trend_datasets :
-    - 
+    - Sasgen_AWIarc_RL01_2
+    - Wouters
+    - Jacob_2012_dmdt
   demdiff_and_glaciological :
     exclude_annual_datasets : # glaciological datasets
     - UZH_GlaciolSineWave

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -227,6 +227,27 @@ class DataCatalogue():
         else:
             return True
 
+    def get_time_span_of_datasets(self) -> Tuple[float, float]:
+        """
+        Returns the time window covered by all datasets within the catalogue
+
+        Returns
+        -------
+        Tuple[float, float]
+            minimum and maximum dates of all datasets combined in catalogue
+            in the form of [min_start_date, max_end_date]
+        """
+        if len(self.datasets) > 0:
+            min_dates = []
+            max_dates = []
+
+            for ds in self.datasets:
+                min_dates.append(ds.data.min_start_date)
+                max_dates.append(ds.data.max_end_date)
+            return np.min(min_dates), np.max(max_dates)
+        else:
+            return None, None
+
     def average_timeseries_in_catalogue(self, remove_trend: bool = True, add_trend_after_averaging: bool = False,
                                         out_data_group: GlambieDataGroup = GLAMBIE_DATA_GROUPS["consensus"]) \
             -> Tuple[Timeseries, DataCatalogue]:

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -249,7 +249,8 @@ class DataCatalogue():
             return None, None
 
     def average_timeseries_in_catalogue(self, remove_trend: bool = True, add_trend_after_averaging: bool = False,
-                                        out_data_group: GlambieDataGroup = GLAMBIE_DATA_GROUPS["consensus"]) \
+                                        out_data_group: GlambieDataGroup = GLAMBIE_DATA_GROUPS["consensus"],
+                                        out_user_group: str = "consensus") \
             -> Tuple[Timeseries, DataCatalogue]:
         """
         Calculates a simple average of all timeseries within the catalogue, with the option to remove trends
@@ -264,8 +265,11 @@ class DataCatalogue():
             this flag is only active when remove_trend is set to True.
             by default False
         out_data_group : GlambieDataGroup, optional
-            data group to be assigned to combined output Timeseries metadata,
+            data group to be assigned to combined output Timeseries metadata
             by default GLAMBIE_DATA_GROUPS["consensus"]
+        out_user_group : str, optional
+            user group to be assigned to combined output Timeseries metadata
+            by default 'consensus'
 
 
         Returns
@@ -351,7 +355,7 @@ class DataCatalogue():
         reference_dataset_for_metadata = self.datasets[0]  # use this as a reference for filling metadata
 
         return Timeseries(region=reference_dataset_for_metadata.region, data_group=out_data_group,
-                          data=ts_data, unit=reference_dataset_for_metadata.unit,
+                          data=ts_data, unit=reference_dataset_for_metadata.unit, user_group=out_user_group,
                           area_change_applied=reference_dataset_for_metadata.area_change_applied), data_catalogue_out
 
     def __len__(self) -> int:

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -307,8 +307,6 @@ class DataCatalogue():
                 df["changes"] = df["changes"] - df_sub["changes"].mean()
                 data_catalogue_out.datasets[idx].data.changes = np.array(df["changes"])
                 change_means_over_period.append(df_sub["changes"].mean())
-                if add_trend_after_averaging and remove_trend:
-                    df["errors"] = df["errors"] - df_sub["errors"].mean()
 
         # join all catalogues by start and end dates
         # the resulting dataframe has a set of columns with repeating prefixes

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -377,7 +377,7 @@ class Timeseries():
                 # First remove area uncertainty
                 # area_unc is calculated as a % of the total area. % can be defined individually per region.
                 area_unc = glacier_area * self.region.area_uncertainty_percentage
-                errors_area_unc_removed = (  # inverting the formula from glambie ATBD
+                errors_area_unc_removed = np.abs(  # inverting the formula from glambie ATBD
                     object_copy.data.changes * np.abs(
                         object_copy.data.errors**2 * glacier_area**2
                         - np.abs(object_copy.data.changes)**2 * area_unc**2)**0.5) / (

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -523,7 +523,7 @@ def _run_region_trends_for_one_source(
     """
 
     log.info("Recalibrating with longterm trends within data group and region...")
-    # get catalogue with longerm datasets in same unit as calibration dataset (mwe)
+    # get catalogue with longterm datasets in same unit as calibration dataset (mwe)
     data_catalogue_trends_homogenized = convert_datasets_to_longterm_trends_in_unit_mwe(
         data_catalogue_trends, year_type=year_type,
         seasonal_calibration_dataset=seasonal_calibration_dataset,
@@ -540,7 +540,9 @@ def _run_region_trends_for_one_source(
     # recalibrate
     catalogue_calibrated_series = calibrate_timeseries_with_trends_catalogue(
         data_catalogue_trends_homogenized, annual_combined_full_ext)
-    # we dont remove trends as these are calibrated series with trends
+    # now combine the calibrated timeseries
+    # the trends are not removed when combining, because the dfferences in periods are already reflected
+    # with the annual variability dataset
     trend_combined, _ = catalogue_calibrated_series.average_timeseries_in_catalogue(remove_trend=False,
                                                                                     out_data_group=data_group)
     return trend_combined, data_catalogue_trends_homogenized, catalogue_calibrated_series

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -65,8 +65,6 @@ def run_one_region(glambie_run_config: GlambieRunConfig,
         backup_dataset=seasonal_calibration_dataset,
         desired_time_span=[glambie_run_config.start_year, glambie_run_config.end_year])
 
-    # season_calibration_dataset.copy()
-
     result_datasets = []
     for data_group in glambie_run_config.datagroups_to_calculate:
         log.info('Starting to process region=%s datagroup=%s', region_config.region_name, data_group.name)

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Tuple
+import numpy as np
 
 from glambie.config.config_classes import GlambieRunConfig, RegionRunConfig
 from glambie.const.constants import ExtractTrendsMethod, GraceGap, YearType, SeasonalCorrectionMethod
@@ -192,6 +193,9 @@ def _prepare_consensus_variability_for_one_region(
         annual_timeseries=consensus_annual,
         timeseries_for_extension=backup_dataset,
         desired_time_window=desired_time_span)
+
+    # now we set all uncertainties to 0 so that they are not doublecounted when combined with the consensus
+    consensus_annual_full_ext.data.errors = np.zeros(len(consensus_annual_full_ext.data.errors))
 
     return consensus_annual_full_ext
 

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -176,7 +176,7 @@ def convert_datasets_to_annual_trends(data_catalogue: DataCatalogue,
     year_type : YearType
         type of annual year, e.g hydrological or calendar
     method_to_correct_seasonally: SeasonalCorrectionMethod
-        method as to how long-term trends are correct when they don't start in the desired season, i.e. don't follow
+        method as to how annual trends are corrected when they don't start in the desired season, i.e. don't follow
         the desired annual grid defined with 'year_type'
     seasonal_calibration_dataset: Timeseries, by default None
         Timeseries dataset for seasonal calibration if trends are at annual resolution. Will be ignore if seasonal

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -179,7 +179,7 @@ def convert_datasets_to_annual_trends(data_catalogue: DataCatalogue,
         method as to how annual trends are corrected when they don't start in the desired season, i.e. don't follow
         the desired annual grid defined with 'year_type'
     seasonal_calibration_dataset: Timeseries, by default None
-        Timeseries dataset for seasonal calibration if trends are at annual resolution. Will be ignore if seasonal
+        Timeseries dataset for seasonal calibration if trends are at annual resolution. Will be ignored if seasonal
         correction method is not set to SeasonalCorrectionMethod.SEASONAL_HOMOGENIZATION
 
     Returns
@@ -436,18 +436,17 @@ def extend_annual_timeseries_if_shorter_than_time_window(
     if (desired_time_window[0] < min(annual_timeseries_copy.data.start_dates)) \
             or (desired_time_window[1] > max(annual_timeseries_copy.data.end_dates)) \
             or not annual_timeseries_copy.data.is_cumulative_valid():  # or the case where the timeseries has a gap
-        log.info("Extension of annual is performed, as the trends are longer than the annual timeseries")
+        log.info("The trends are longer than the annual timeseries. Extension of annual will be performed.")
 
         # Remove trend of timeseries for extension over the common time period
         catalogue_dfs = [annual_timeseries_copy.data.as_dataframe(), timeseries_for_extension.data.as_dataframe()]
         start_ref_period = np.max([df.start_dates.min() for df in catalogue_dfs])
         end_ref_period = np.min([df.end_dates.max() for df in catalogue_dfs])
         if not start_ref_period < end_ref_period:
-            warnings.warn("Warning when removing trends. No common period detected.")
+            warnings.warn("No common period detected when removing trends.")
         for df in catalogue_dfs:
             df_sub = df[(df["start_dates"] >= start_ref_period) & (df["end_dates"] <= end_ref_period)]
             df["changes"] = df["changes"] - df_sub["changes"].mean()  # edit the dataframe
-            df["errors"] = df["errors"] - df_sub["errors"].mean()  # do the same with errors
 
         # Combine with other timeseries to cover the missing timespan
         df_merged = pd.merge(catalogue_dfs[0], catalogue_dfs[1], on=["start_dates", "end_dates"], how="outer")

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -447,6 +447,7 @@ def extend_annual_timeseries_if_shorter_than_time_window(
         for df in catalogue_dfs:
             df_sub = df[(df["start_dates"] >= start_ref_period) & (df["end_dates"] <= end_ref_period)]
             df["changes"] = df["changes"] - df_sub["changes"].mean()  # edit the dataframe
+            df["errors"] = df["errors"] - df_sub["errors"].mean()  # do the same with errors
 
         # Combine with other timeseries to cover the missing timespan
         df_merged = pd.merge(catalogue_dfs[0], catalogue_dfs[1], on=["start_dates", "end_dates"], how="outer")

--- a/tests/data/test_data_catalogue.py
+++ b/tests/data/test_data_catalogue.py
@@ -207,3 +207,12 @@ def test_average_timeseries_in_catalogue_example_with_trends_removed(example_cat
                               result_timeseries_trend_removed.data.changes)
     assert np.allclose(result_timeseries_trend_removed_added_after_averaging.data.changes,
                        result_timeseries.data.changes)
+
+
+def test_get_time_span_of_datasets(example_catalogue_small):
+    example_catalogue_small.load_all_data()
+    time_span = example_catalogue_small.get_time_span_of_datasets()
+    # make sure all datasets are within the span
+    for ds in example_catalogue_small.datasets:
+        assert ds.data.min_start_date >= time_span[0]
+        assert ds.data.max_end_date <= time_span[1]

--- a/tests/processing/test_processing_helpers.py
+++ b/tests/processing/test_processing_helpers.py
@@ -114,24 +114,6 @@ def glambie_config():
     return GlambieRunConfig.from_yaml(yaml_abspath)
 
 
-@pytest.fixture()
-def example_timeseries_ingested():
-    data = TimeseriesData(start_dates=[2010, 2011, 2012, 2013],
-                          end_dates=[2011, 2012, 2013, 2014],
-                          changes=np.array([1., 2., 3., 4.]),
-                          errors=np.array([1., 2., 3., 4.]),
-                          glacier_area_reference=None,
-                          glacier_area_observed=None,
-                          hydrological_correction_value=None,
-                          remarks=None)
-    ts = Timeseries(rgi_version=6,
-                    unit='m',
-                    data_group=GLAMBIE_DATA_GROUPS['demdiff'],
-                    data=data,
-                    region=REGIONS["iceland"])
-    return ts
-
-
 def test_filter_catalogue_with_config_settings(example_catalogue_1, glambie_config):
     data_group = GLAMBIE_DATA_GROUPS["altimetry"]
     data_catalogue = example_catalogue_1


### PR DESCRIPTION
When combining datasets together in the glambie algorithm it is essential to have an annual variability dataset. This is normally generated per data group individually, however there are data groups that don't have this information in certain regions, or where the annual variability does not span the full length. During the glambie workshop it was decided that this should be filled with the consensus variability from all datasets as defined in the config files. This requires to run the combination of annual variability into a consensus before running the algorithm in that region.

Note that depending on the run settings the consensus variability can still not end up spanning the whole length (e.g. in the case the run defines only one data_group), meaning that as a backup dataset the seasonal calibration dataset is used to fill the gaps.

This PR made changes to make that happen which includes:
- split up and refactoring of several functions (for variability and trends) which are used by the consensus variability as well as later in the algorithm: "_run_region_variability_for_one_source()" and "_run_region_trends_for_one_source()"
- ability to define time windows for a span of a timeseries, so that the consensus can be extended with the backup dataset if needed in "extend_annual_timeseries_if_shorter_than_time_window()". For this the ability to query min and max of all datasets combined in a data catalogue has also been added.
- New function which prepares the annual consensus variability "_prepare_consensus_variability_for_one_region()"
- Some quick fixes in the uncertainty calculation

