### PR TITLE
Enable uncertainty levels

### DIFF
--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -549,7 +549,9 @@ class DataCatalogue:
             uncertainty_level=reference_dataset_for_metadata.uncertainty_level
         ), data_catalogue_out
 
-    def convert_all_datasets_to_uncertainty_level(self, target_uncertainty_level: int) -> DataCatalogue:
+    def convert_all_datasets_to_uncertainty_level(
+        self, target_uncertainty_level: int
+    ) -> DataCatalogue:
         """
         Converts the uncertainty values of all datasets in the catalogue to the target uncertainty level.
 
@@ -563,7 +565,10 @@ class DataCatalogue:
         DataCatalogue
             New data catalogue with all datasets converted to the target uncertainty level.
         """
-        datasets = [ds.convert_timeseries_uncertainty_level(target_uncertainty_level) for ds in self._datasets]
+        datasets = [
+            ds.convert_timeseries_uncertainty_level(target_uncertainty_level)
+            for ds in self._datasets
+        ]
         return DataCatalogue.from_list(datasets, base_path=self._base_path)
 
     def __len__(self) -> int:

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -420,7 +420,8 @@ class DataCatalogue:
             )
         if not self.datasets_are_same_uncertainty_level(95):
             raise AssertionError(
-                "Timeseries within catalogue need to be sigma-2 (95%) uncertainty level before performing this operation."
+                "Timeseries within catalogue need to be sigma-2 (95%) "
+                "uncertainty level before performing this operation."
             )
 
         # merge all dataframes

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -18,6 +18,27 @@ import numpy as np
 import copy
 
 
+def _parse_uncertainty_level(
+    metadata: dict,
+    field_name: str,
+    default: int = 95,
+) -> int:
+    uncertainty_level = metadata.get(field_name, default)
+    if uncertainty_level is None or pd.isna(uncertainty_level):
+        return default
+
+    if isinstance(uncertainty_level, str):
+        uncertainty_level = uncertainty_level.strip().rstrip("%")
+
+    if str(uncertainty_level) in {"68", "95"}:
+        return int(uncertainty_level)
+
+    raise ValueError(
+        f"Unsupported uncertainty level in field '{field_name}': "
+        f"{uncertainty_level!r}"
+    )
+
+
 class DataCatalogue:
     """Class containing a catalogue of datasets"""
 
@@ -78,6 +99,10 @@ class DataCatalogue:
                 user_group=metadata["user_group"],
                 rgi_version=rgi_version,
                 additional_metadata=additional_metadata,
+                uncertainty_level=_parse_uncertainty_level(
+                    metadata,
+                    field_name="uncertainties_select",
+                ),
             )
             dataset.load_data()
             datasets.append(dataset)
@@ -128,6 +153,10 @@ class DataCatalogue:
             data_group = GLAMBIE_DATA_GROUPS[ds_dict["data_group"]]
             user_group = ds_dict["user_group"]
             unit = ds_dict["unit"]
+            uncertainty_level = _parse_uncertainty_level(
+                ds_dict,
+                field_name="uncertainty_level",
+            )
             datasets.append(
                 Timeseries(
                     data_filepath=fp,
@@ -135,6 +164,7 @@ class DataCatalogue:
                     data_group=data_group,
                     user_group=user_group,
                     unit=unit,
+                    uncertainty_level=uncertainty_level,
                 )
             )
 

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -269,6 +269,7 @@ class DataCatalogue:
     def is_all_data_loaded(self) -> bool:
         """
         Checks if all datasets in the catalogue have their data loaded.
+        Note that this will also return True if the catalogue is empty.
 
         Returns
         -------
@@ -419,18 +420,18 @@ class DataCatalogue:
 
         Raises
         ------
-        AssertionError
+        ValueError
             If timeseries within catalogue are not all the same unit.
-        AssertionError
+        ValueError
             If timeseries within catalogue are not all provided at sigma-2 (95%) uncertainty level.
         """
 
         if not self.datasets_are_same_unit():
-            raise AssertionError(
+            raise ValueError(
                 "Timeseries within catalogue need to be same unit before performing this operation."
             )
         if not self.datasets_are_same_uncertainty_level(95):
-            raise AssertionError(
+            raise ValueError(
                 "Timeseries within catalogue need to be sigma-2 (95%) "
                 "uncertainty level before performing this operation."
             )

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -546,6 +546,7 @@ class DataCatalogue:
             unit=reference_dataset_for_metadata.unit,
             user_group=out_user_group,
             area_change_applied=reference_dataset_for_metadata.area_change_applied,
+            uncertainty_level=reference_dataset_for_metadata.uncertainty_level
         ), data_catalogue_out
 
     def __len__(self) -> int:

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -281,6 +281,32 @@ class DataCatalogue:
         else:
             return True
 
+    def datasets_are_same_uncertainty_level(self, uncertainty_level: int | str):
+        """
+        Checks if all datasets within catalogue have the same uncertainty level.
+
+        Parameters
+        ----------
+        uncertainty_level : int | str
+            uncertainty level to compare against; supported values are 68, 95, "68%", and "95%".
+
+        Returns
+        -------
+        bool
+            True if all datasets have the same uncertainty level, False otherwise.
+        """
+        parsed_uncertainty_level = _parse_uncertainty_level(
+            {"uncertainty_level": uncertainty_level},
+            field_name="uncertainty_level",
+        )
+        if len(self.datasets) > 0:
+            return all(
+                dataset.uncertainty_level == parsed_uncertainty_level
+                for dataset in self.datasets
+            )
+        else:
+            return True
+
     def get_common_period_of_datasets(self) -> Tuple[np.array, np.array]:
         """
         Calculates arrays of the common period in all datasets of the catalogue
@@ -384,11 +410,17 @@ class DataCatalogue:
         ------
         AssertionError
             If timeseries within catalogue are not all the same unit.
+        AssertionError
+            If timeseries within catalogue are not all provided at sigma-2 (95%) uncertainty level.
         """
 
         if not self.datasets_are_same_unit():
             raise AssertionError(
                 "Timeseries within catalogue need to be same unit before performing this operation."
+            )
+        if not self.datasets_are_same_uncertainty_level(95):
+            raise AssertionError(
+                "Timeseries within catalogue need to be sigma-2 (95%) uncertainty level before performing this operation."
             )
 
         # merge all dataframes

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -549,6 +549,23 @@ class DataCatalogue:
             uncertainty_level=reference_dataset_for_metadata.uncertainty_level
         ), data_catalogue_out
 
+    def convert_all_datasets_to_uncertainty_level(self, target_uncertainty_level: int) -> DataCatalogue:
+        """
+        Converts the uncertainty values of all datasets in the catalogue to the target uncertainty level.
+
+        Parameters
+        ----------
+        target_uncertainty_level : int
+            Target uncertainty level to convert to. Must be 68 or 95.
+
+        Returns
+        -------
+        DataCatalogue
+            New data catalogue with all datasets converted to the target uncertainty level.
+        """
+        datasets = [ds.convert_timeseries_uncertainty_level(target_uncertainty_level) for ds in self._datasets]
+        return DataCatalogue.from_list(datasets, base_path=self._base_path)
+
     def __len__(self) -> int:
         return len(self._datasets)
 

--- a/glambie/data/data_catalogue.py
+++ b/glambie/data/data_catalogue.py
@@ -266,6 +266,17 @@ class DataCatalogue:
             if not dataset.is_data_loaded:
                 dataset.load_data()
 
+    def is_all_data_loaded(self) -> bool:
+        """
+        Checks if all datasets in the catalogue have their data loaded.
+
+        Returns
+        -------
+        bool
+            True if all datasets have data loaded, False otherwise
+        """
+        return all(dataset.is_data_loaded for dataset in self.datasets)
+
     def datasets_are_same_unit(self):
         """
         Checks if all datasets within catalogue have the same unit

--- a/glambie/data/data_catalogue_helpers.py
+++ b/glambie/data/data_catalogue_helpers.py
@@ -29,18 +29,18 @@ def calibrate_timeseries_with_trends_catalogue(
 
     Raises
     ------
-        AssertionError
+        ValueError
             If trends are not all the same unit.
-        AssertionError
+        ValueError
             If trends are not all provided at sigma-2 (95%) uncertainty level.
     """
 
     if not catalogue_with_trends.datasets_are_same_unit():
-        raise AssertionError(
+        raise ValueError(
             "Trends within catalogue all need to be the same unit before performing this operation."
         )
     if not catalogue_with_trends.datasets_are_same_uncertainty_level(95):
-        raise AssertionError(
+        raise ValueError(
             "Trends within catalogue all need to be sigma-2 (95%) uncertainty level before performing this operation."
         )
 

--- a/glambie/data/data_catalogue_helpers.py
+++ b/glambie/data/data_catalogue_helpers.py
@@ -31,11 +31,17 @@ def calibrate_timeseries_with_trends_catalogue(
     ------
         AssertionError
             If trends are not all the same unit.
+        AssertionError
+            If trends are not all provided at sigma-2 (95%) uncertainty level.
     """
 
     if not catalogue_with_trends.datasets_are_same_unit():
         raise AssertionError(
             "Trends within catalogue all need to be the same unit before performing this operation."
+        )
+    if not catalogue_with_trends.datasets_are_same_uncertainty_level(95):
+        raise AssertionError(
+            "Trends within catalogue all need to be sigma-2 (95%) uncertainty level before performing this operation."
         )
 
     # calibrate annual trends with longterm trend

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -234,6 +234,7 @@ class Timeseries:
         rgi_version: int = None,
         unit: str = None,
         additional_metadata: dict = None,
+        uncertainty_level: int | None = None,
         area_change_applied: bool = False,
     ):
         """
@@ -278,6 +279,7 @@ class Timeseries:
         self.data_filepath = data_filepath
         self.data = data
         self.additional_metadata = additional_metadata
+        self.uncertainty_level = uncertainty_level
         if self.data is not None:
             self.is_data_loaded = True
         self.area_change_applied = area_change_applied
@@ -332,6 +334,7 @@ class Timeseries:
             "user_group": self.user_group,
             "rgi_version": self.rgi_version,
             "unit": self.unit,
+            "uncertainty_level": self.uncertainty_level,
         }
         if self.additional_metadata is not None:
             metadata_dict.update(self.additional_metadata)

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -429,11 +429,11 @@ class Timeseries:
 
         Raises
         ------
-        AssertionError
+        ValueError
             If current uncertainty level is not set.
         """
         if self.uncertainty_level not in {68, 95} or target_uncertainty_level not in {68, 95}:
-            raise AssertionError(
+            raise ValueError(
                 "Cannot convert uncertainty level: both current and target uncertainty levels must be 68 or 95."
             )
 
@@ -586,14 +586,14 @@ class Timeseries:
         ------
         NotImplementedError
             For units to be converted that are not implemented yet
-        AssertionError
+        ValueError
             When area_change_applied is True.
             Varying glacier area should only be applied to specific changes (meters or meters water equivalent)
             and should be removed before converting to Gigatonnes as we are using a constant area when converting
             to Gigatonnes. For more information refer to the GlaMBIE algorithm description document section 4.3.
         """
         if self.area_change_applied:
-            raise AssertionError(
+            raise ValueError(
                 "Cannot convert dataset to Gt. Area change needs to be removed first."
             )
 
@@ -667,23 +667,23 @@ class Timeseries:
 
         Raises
         ------
-        AssertionError
+        ValueError
             When units are not either 'm' or 'mwe'
-        AssertionError
+        ValueError
             When trying to apply area change on a dataset where it's already applied
-        AssertionError
+        ValueError
             When trying to remove area change on a dataset where it's not already applied
         """
         if self.unit not in ["mwe", "m"]:
-            raise AssertionError(
+            raise ValueError(
                 "Area change should only be applied/removed to 'm' or 'mwe'."
             )
         if self.area_change_applied and apply_area_change:
-            raise AssertionError(
+            raise ValueError(
                 "Area change is already applied to current dataset. Cannot be applied again."
             )
         if not self.area_change_applied and not apply_area_change:
-            raise AssertionError(
+            raise ValueError(
                 "Area change is not applied to current dataset. Cannot be removed."
             )
 
@@ -826,14 +826,14 @@ class Timeseries:
 
         Raises
         ------
-        AssertionError
+        ValueError
             Thrown if timeseries is not on monthly grid.
-        AssertionError
+        ValueError
             Thrown for resolutions > 1 year if timeseries is not on annual grid.
         """
         # Check if on monthly grid. if not throw an exception
         if not self.timeseries_is_monthly_grid():
-            raise AssertionError(
+            raise ValueError(
                 "Timeseries needs to be converted to monthly grid before performing this operation."
             )
 
@@ -878,7 +878,7 @@ class Timeseries:
         # 2) Case where resolution is >= a year: we upsample and take the average from the longterm trend
         else:  # make sure that the trends don't start in the middle of the year
             if not self.timeseries_is_annual_grid(year_type=year_type):
-                raise AssertionError(
+                raise ValueError(
                     "Timeseries needs to fit into annual grid before \
                                      up-sampling to annual changes."
                 )
@@ -985,29 +985,29 @@ class Timeseries:
 
         Raises
         ------
-        AssertionError
+        ValueError
             Thrown if timeseries is not on monthly grid.
-        AssertionError
+        ValueError
             Thrown if calibration dataset is not on monthly grid.
-        AssertionError
+        ValueError
             Thrown if timeseries resolution below a year.
         """
         # first some checks if inputs area valid
         if not self.timeseries_is_monthly_grid():
-            raise AssertionError(
+            raise ValueError(
                 "Timeseries needs to be converted to monthly grid before performing this operation."
             )
         if not seasonal_calibration_dataset.timeseries_is_monthly_grid():
-            raise AssertionError(
+            raise ValueError(
                 "Seasonal calibration dataset needs to be converted to monthly grid"
                 "before performing this operation."
             )
         if self.data.max_temporal_resolution < 1:
-            raise AssertionError(
+            raise ValueError(
                 "Resolution of timeseries is below a year. No seasonal homogenization possible."
             )
         if not self.unit == seasonal_calibration_dataset.unit:
-            raise AssertionError(
+            raise ValueError(
                 "Seasonal calibration dataset and dataset unit should be the same, however "
                 f"they are units {seasonal_calibration_dataset.unit} and {self.unit}."
             )
@@ -1170,12 +1170,12 @@ class Timeseries:
 
         Raises
         ------
-        AssertionError
+        ValueError
             Thrown if timeseries resolution is higher than a year (we here assume higher than 11 months to allow
             some margin). In that case the operation cannot be performed.
         """
         if self.data.max_temporal_resolution < 11 / 12:
-            raise AssertionError(
+            raise ValueError(
                 "Resolution of timeseries is higher than a year. Operation not possible."
             )
 

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -407,6 +407,41 @@ class Timeseries:
         df_data.dropna(how="all", axis=1, inplace=True)  # drop empty columns
         df_data.to_csv(csv_outpath, index=False)
 
+    def convert_timeseries_uncertainty_level(
+        self, target_uncertainty_level: int
+    ) -> Timeseries:
+        """
+        Converts uncertainty values between sigma-1 (68%) and sigma-2 (95%).
+
+        Parameters
+        ----------
+        target_uncertainty_level : int
+            target uncertainty level as 68 or 95.
+
+        Returns
+        -------
+        Timeseries
+            A copy of the Timeseries object with converted uncertainty values and updated uncertainty level.
+
+        Raises
+        ------
+        AssertionError
+            If current uncertainty level is not set.
+        """
+        if self.uncertainty_level not in {68, 95} or target_uncertainty_level not in {68, 95}:
+            raise AssertionError(
+                "Cannot convert uncertainty level: both current and target uncertainty levels must be 68 or 95."
+            )
+
+        object_copy = self.copy()
+        if self.uncertainty_level == target_uncertainty_level:
+            return object_copy
+
+        conversion_factor = 1.96 if target_uncertainty_level == 95 else 1 / 1.96
+        object_copy.data.errors = np.array(object_copy.data.errors * conversion_factor)
+        object_copy.uncertainty_level = target_uncertainty_level
+        return object_copy
+
     def convert_timeseries_to_unit_mwe(
         self,
         rgi_area_version: int,

--- a/glambie/data/timeseries.py
+++ b/glambie/data/timeseries.py
@@ -286,7 +286,11 @@ class Timeseries:
 
     def load_data(self) -> TimeseriesData:
         """Reads data into class from specified filepath or gs:// bucket URI.
+
+        If data is already loaded, returns the existing data without reloading.
         """
+        if self.is_data_loaded:
+            return self.data
         if self.data_filepath is None:
             raise ValueError("Can not load data: file path not set")
 

--- a/glambie/plot/plot_helpers.py
+++ b/glambie/plot/plot_helpers.py
@@ -117,7 +117,7 @@ def apply_vertical_adjustment_for_cumulative_plot(
             )
             ts_new = pd.DataFrame({"dates": monthly_grid, "changes": changes})
             # handle Nan values, e.g. when there is a gap in the timeseries
-            ts_new = ts_new.fillna(method="bfill")
+            ts_new = ts_new.bfill()
             adjustment = ts_new[ts_new.dates == adjustment_date].iloc[0].changes
     else:
         # this means we adjust the adjustment series at the first date of the reference series

--- a/glambie/processing/main.py
+++ b/glambie/processing/main.py
@@ -41,10 +41,14 @@ def run_glambie_assessment(
     data_catalogue_original = DataCatalogue.from_glambie_submission_system(glambie_bucket_name=glambie_bucket_name)
     data_catalogue_original.load_all_data()
 
+    # Initial homogenisation of datasets in data catalogue
+    # Convert all datasets to sigma 2 (95%) uncertainty level
+    data_catalogue = data_catalogue_original.convert_all_datasets_to_uncertainty_level(95)
+
     # run regional results
     results_catalogue_combined_per_region_mwe, _ = _run_regional_results(
         glambie_run_config,
-        data_catalogue_original,
+        data_catalogue,
         output_path_handler=output_path_handler,
     )
 
@@ -81,7 +85,7 @@ def _run_regional_results(
         - Data Catalogue with regional results. Contains one timeseries per region specified to run within the config.
         First element is in unit mwe, second element is in unit Gt
     """
-    # data_group_results_per_region = []
+    # Run per region
     combined_regional_results_mwe = []
     combined_regional_results_gt = []
     for region_config in glambie_run_config.regions:

--- a/glambie/processing/process_global_results.py
+++ b/glambie/processing/process_global_results.py
@@ -212,6 +212,9 @@ def _combine_regional_results_into_global(
         Globally aggregated timeseries in input unit
     """
     assert regional_results_catalogue.datasets_are_same_unit()
+    assert regional_results_catalogue.datasets_are_same_uncertainty_level(95), (
+        "Regional results must all be sigma-2 (95%) uncertainty level before combining into global."
+    )
     assert (
         regional_results_catalogue.datasets[0].unit == "mwe"
         or regional_results_catalogue.datasets[0].unit.lower() == "gt"
@@ -310,4 +313,5 @@ def _combine_regional_results_into_global(
         data_group=GLAMBIE_DATA_GROUPS["consensus"],
         data=ts_data,
         unit=reference_dataset_for_metadata.unit,
+        uncertainty_level=reference_dataset_for_metadata.uncertainty_level,
     )

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -76,6 +76,10 @@ def run_one_region(
         region_name=region_config.region_name
     )
 
+    # ensure that data in catalogue is already loaded, as we will be using the data in memory for processing
+    if not data_catalogue.is_all_data_loaded():
+        raise ValueError("Expected all datasets in data_catalogue to be loaded before processing.")
+
     # get seasonal calibration dataset and convert to monthly grid
     seasonal_calibration_dataset = prepare_seasonal_calibration_dataset(
         region_config,

--- a/glambie/processing/process_regional_results.py
+++ b/glambie/processing/process_regional_results.py
@@ -113,9 +113,6 @@ def run_one_region(
             == len(data_catalogue_trends.datasets)
             == 0
         ):
-            # read data in catalogue
-            data_catalogue_annual.load_all_data()
-            data_catalogue_trends.load_all_data()
 
             data_catalogue_annual = set_unneeded_columns_to_nan(data_catalogue_annual)
             data_catalogue_trends = set_unneeded_columns_to_nan(data_catalogue_trends)
@@ -229,8 +226,6 @@ def _prepare_consensus_variability_for_one_region(
             data_catalogue=data_catalogue,
         )
         if len(data_catalogue_annual.datasets) != 0:
-            # read data in catalogue
-            data_catalogue_annual.load_all_data()
             data_catalogue_annual = set_unneeded_columns_to_nan(data_catalogue_annual)
             data_catalogue_annual = convert_datasets_to_monthly_grid(data_catalogue_annual)
             # remove GRACE gap from annual catalogue so that the variability isn't impacted by the lower resolution gap

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -414,7 +414,7 @@ def apply_seasonal_correction_to_dataset(
     """
     if method_to_correct_seasonally == SeasonalCorrectionMethod.SEASONAL_HOMOGENIZATION:
         if seasonal_calibration_dataset is None:
-            raise AssertionError(
+            raise ValueError(
                 "Seasonal calibration dataset is None, cannot perform operation."
             )
         corrected_dataset = dataset_to_correct.shift_timeseries_to_annual_grid_with_seasonal_homogenization(

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -526,7 +526,6 @@ def prepare_seasonal_calibration_dataset(
         user_group=region_config.seasonal_correction_dataset["user_group"],
         data_group=region_config.seasonal_correction_dataset["data_group"],
     ).datasets[0]
-    season_calibration_dataset.load_data()
     season_calibration_dataset = (
         season_calibration_dataset.convert_timeseries_to_monthly_grid()
     )

--- a/glambie/processing/processing_helpers.py
+++ b/glambie/processing/processing_helpers.py
@@ -504,8 +504,10 @@ def prepare_seasonal_calibration_dataset(
     """
     Retrieves and prepares the seasonal calibration dataset from a data catalogue.
 
-    In this function the seasonal calibration dataset is loaded, standardised date axis to a monthly grid
-    and then converted to unit mwe
+    In this function the seasonal calibration dataset is standardised by converting date axis to a monthly grid
+    and then converting the dataset to unit mwe.
+
+    The function assumes that the seasonal calibration dataset is available and loaded in the catalogue
 
     Parameters
     ----------
@@ -526,6 +528,7 @@ def prepare_seasonal_calibration_dataset(
         user_group=region_config.seasonal_correction_dataset["user_group"],
         data_group=region_config.seasonal_correction_dataset["data_group"],
     ).datasets[0]
+    assert season_calibration_dataset.is_data_loaded
     season_calibration_dataset = (
         season_calibration_dataset.convert_timeseries_to_monthly_grid()
     )

--- a/tests/data/test_data_catalogue.py
+++ b/tests/data/test_data_catalogue.py
@@ -74,6 +74,27 @@ def test_data_catalogue_datasets_correctly_ingested(example_catalogue):
     assert example_catalogue.datasets[1].data_group.name == "altimetry"
     assert example_catalogue.datasets[2].data_group.name == "gravimetry"
     assert example_catalogue.datasets[0].unit == "m"
+    assert example_catalogue.datasets[0].uncertainty_level == 95
+
+
+def test_data_catalogue_from_dict_with_uncertainty_level():
+    catalogue = DataCatalogue.from_dict(
+        {
+            "base_path": ["tests", "test_data", "datastore"],
+            "datasets": [
+                {
+                    "filename": "iceland_altimetry_sharks.csv",
+                    "region": "iceland",
+                    "user_group": "sharks",
+                    "data_group": "altimetry",
+                    "unit": "m",
+                    "uncertainty_level": "68%",
+                },
+            ],
+        }
+    )
+
+    assert catalogue.datasets[0].uncertainty_level == 68
 
 
 def test_get_filtered_catalogue_by_region(example_catalogue):
@@ -181,6 +202,8 @@ def test_data_catalogue_from_submission_system_glambie_1_format():
         catalogue.datasets[1].additional_metadata["lead_author_date_of_birth"]
         == "May 18th 1889"
     )
+    assert catalogue.datasets[0].uncertainty_level == 95
+    assert catalogue.datasets[1].uncertainty_level == 95
 
 
 def test_data_catalogue_from_submission_system_glambie_2_format():
@@ -201,6 +224,7 @@ def test_data_catalogue_from_submission_system_glambie_2_format():
                 "user_group": "authors-altimetry",
                 "rgi_version_select": "6.0",
                 "lead_author_date_of_birth": "May 18th 1889",
+                "uncertainties_select": "68%",
             },
             {
                 "region": "ISL",
@@ -209,6 +233,7 @@ def test_data_catalogue_from_submission_system_glambie_2_format():
                 "user_group": "authors-gravimetry",
                 "rgi_version_select": "6.0",
                 "lead_author_date_of_birth": "May 18th 1889",
+                "uncertainties_select": "95%",
             },
         ]
         # and return some fake data
@@ -232,6 +257,8 @@ def test_data_catalogue_from_submission_system_glambie_2_format():
         catalogue.datasets[1].additional_metadata["lead_author_date_of_birth"]
         == "May 18th 1889"
     )
+    assert catalogue.datasets[0].uncertainty_level == 68
+    assert catalogue.datasets[1].uncertainty_level == 95
 
 
 def test_data_catalogue_regions(example_catalogue):

--- a/tests/data/test_data_catalogue.py
+++ b/tests/data/test_data_catalogue.py
@@ -284,20 +284,27 @@ def test_datasets_are_same_unit(example_catalogue):
     assert not example_catalogue.datasets_are_same_unit()
 
 
-def test_datasets_are_same_uncertainty_level(example_catalogue):
-    # all test datasets are 95 by default
-    assert example_catalogue.datasets_are_same_uncertainty_level(95)
-    assert example_catalogue.datasets_are_same_uncertainty_level("95%")
+@pytest.mark.parametrize(
+    "updated_levels, uncertainty_level, expected",
+    [
+        (None, 95, True),
+        (None, "95%", True),
+        ([68, 95, 95], 95, False),
+        ([68, 95, 95], 68, False),
+        ([68, 68, 68], 68, True),
+    ],
+)
+def test_datasets_are_same_uncertainty_level(
+    example_catalogue, updated_levels, uncertainty_level, expected
+):
+    if updated_levels is not None:
+        for dataset, level in zip(example_catalogue.datasets, updated_levels):
+            dataset.uncertainty_level = level
 
-    # make one dataset 68 and ensure mixed levels fail the check
-    example_catalogue.datasets[0].uncertainty_level = 68
-    assert not example_catalogue.datasets_are_same_uncertainty_level(95)
-    assert not example_catalogue.datasets_are_same_uncertainty_level(68)
-
-    # set all to 68 to verify successful match
-    for dataset in example_catalogue.datasets:
-        dataset.uncertainty_level = 68
-    assert example_catalogue.datasets_are_same_uncertainty_level(68)
+    assert (
+        example_catalogue.datasets_are_same_uncertainty_level(uncertainty_level)
+        == expected
+    )
 
 
 def test_data_catalogue_copy(example_catalogue_small):

--- a/tests/data/test_data_catalogue.py
+++ b/tests/data/test_data_catalogue.py
@@ -285,7 +285,7 @@ def test_datasets_are_same_unit(example_catalogue):
 
 
 @pytest.mark.parametrize(
-    "updated_levels, uncertainty_level, expected",
+    ("updated_levels", "uncertainty_level", "expected"),
     [
         (None, 95, True),
         (None, "95%", True),

--- a/tests/data/test_data_catalogue.py
+++ b/tests/data/test_data_catalogue.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch
 
 from glambie.data.data_catalogue import DataCatalogue
+from glambie.data.data_catalogue_helpers import calibrate_timeseries_with_trends_catalogue
 from glambie.data.timeseries import TimeseriesData
 import pytest
 import copy
@@ -283,6 +284,22 @@ def test_datasets_are_same_unit(example_catalogue):
     assert not example_catalogue.datasets_are_same_unit()
 
 
+def test_datasets_are_same_uncertainty_level(example_catalogue):
+    # all test datasets are 95 by default
+    assert example_catalogue.datasets_are_same_uncertainty_level(95)
+    assert example_catalogue.datasets_are_same_uncertainty_level("95%")
+
+    # make one dataset 68 and ensure mixed levels fail the check
+    example_catalogue.datasets[0].uncertainty_level = 68
+    assert not example_catalogue.datasets_are_same_uncertainty_level(95)
+    assert not example_catalogue.datasets_are_same_uncertainty_level(68)
+
+    # set all to 68 to verify successful match
+    for dataset in example_catalogue.datasets:
+        dataset.uncertainty_level = 68
+    assert example_catalogue.datasets_are_same_uncertainty_level(68)
+
+
 def test_data_catalogue_copy(example_catalogue_small):
     example_catalogue_small.load_all_data()
     example_catalogue_copy = example_catalogue_small.copy()
@@ -364,6 +381,44 @@ def test_average_timeseries_in_catalogue_example_with_trends_removed(
         result_timeseries_trend_removed_added_after_averaging.data.changes,
         result_timeseries.data.changes,
     )
+
+
+def test_average_timeseries_in_catalogue_requires_sigma2_uncertainty(
+    example_catalogue_small,
+):
+    example_catalogue_small.load_all_data()
+    example_catalogue_small.datasets.append(
+        copy.deepcopy(example_catalogue_small.datasets[0])
+    )
+    example_catalogue_small.datasets[0].uncertainty_level = 68
+
+    with pytest.raises(
+        AssertionError,
+        match=r"sigma-2 \(95%\) uncertainty level",
+    ):
+        example_catalogue_small.average_timeseries_in_catalogue(
+            remove_trend=False, add_trend_after_averaging=False
+        )
+
+
+def test_calibrate_timeseries_with_trends_catalogue_requires_sigma2_uncertainty(
+    example_catalogue_small,
+):
+    example_catalogue_small.load_all_data()
+    example_catalogue_small.datasets.append(
+        copy.deepcopy(example_catalogue_small.datasets[0])
+    )
+    example_catalogue_small.datasets[0].uncertainty_level = 68
+
+    calibration_timeseries = copy.deepcopy(example_catalogue_small.datasets[1])
+    with pytest.raises(
+        AssertionError,
+        match=r"sigma-2 \(95%\) uncertainty level",
+    ):
+        calibrate_timeseries_with_trends_catalogue(
+            catalogue_with_trends=example_catalogue_small,
+            calibration_timeseries=calibration_timeseries,
+        )
 
 
 def test_get_time_span_of_datasets(example_catalogue_small):

--- a/tests/data/test_data_catalogue.py
+++ b/tests/data/test_data_catalogue.py
@@ -393,7 +393,7 @@ def test_average_timeseries_in_catalogue_requires_sigma2_uncertainty(
     example_catalogue_small.datasets[0].uncertainty_level = 68
 
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match=r"sigma-2 \(95%\) uncertainty level",
     ):
         example_catalogue_small.average_timeseries_in_catalogue(
@@ -412,7 +412,7 @@ def test_calibrate_timeseries_with_trends_catalogue_requires_sigma2_uncertainty(
 
     calibration_timeseries = copy.deepcopy(example_catalogue_small.datasets[1])
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match=r"sigma-2 \(95%\) uncertainty level",
     ):
         calibrate_timeseries_with_trends_catalogue(

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -789,6 +789,48 @@ def test_reduce_to_date_window_with_gap(example_timeseries_ingested):
     )
 
 
+def test_convert_timeseries_uncertainty_level_68_to_95(example_timeseries_ingested):
+    example_timeseries_ingested.uncertainty_level = 68
+
+    converted_timeseries = (
+        example_timeseries_ingested.convert_timeseries_uncertainty_level(95)
+    )
+
+    assert converted_timeseries.uncertainty_level == 95
+    assert np.allclose(
+        converted_timeseries.data.errors,
+        example_timeseries_ingested.data.errors * 1.96,
+    )
+
+
+def test_convert_timeseries_uncertainty_level_95_to_68(example_timeseries_ingested):
+    example_timeseries_ingested.uncertainty_level = 95
+
+    converted_timeseries = (
+        example_timeseries_ingested.convert_timeseries_uncertainty_level(68)
+    )
+
+    assert converted_timeseries.uncertainty_level == 68
+    assert np.allclose(
+        converted_timeseries.data.errors,
+        example_timeseries_ingested.data.errors / 1.96,
+    )
+
+
+def test_convert_timeseries_uncertainty_level_same_level_no_change(example_timeseries_ingested):
+    example_timeseries_ingested.uncertainty_level = 95
+
+    converted_timeseries = (
+        example_timeseries_ingested.convert_timeseries_uncertainty_level(95)
+    )
+
+    assert converted_timeseries.uncertainty_level == 95
+    assert np.array_equal(
+        converted_timeseries.data.errors,
+        example_timeseries_ingested.data.errors,
+    )
+
+
 def test_shift_timeseries_to_annual_grid_proportionally_period_stays_same_length(
     example_timeseries_ingested,
 ):

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -535,7 +535,7 @@ def test_convert_timeseries_to_annual_trends_up_sampling_throws_exception(
     assert not example_timeseries_ingested.timeseries_is_annual_grid()
     with pytest.raises(
         ValueError,
-        match=r"Timeseries needs to fit into annual grid",
+        match=r"Timeseries needs to be converted to monthly grid before performing this operation.",
     ):
         example_timeseries_ingested.convert_timeseries_to_annual_trends()
 

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -23,6 +23,7 @@ def example_timeseries():
             "tests", "test_data", "datastore", "central_asia_demdiff_sharks.csv"
         ),
         additional_metadata={"toves": "slithy", "mome raths": "outgrabe"},
+        uncertainty_level=95
     )
     return ts
 
@@ -111,6 +112,7 @@ def test_data_as_dataframe(example_timeseries_ingested):
 def test_metadata_as_dataframe(example_timeseries):
     df = example_timeseries.metadata_as_dataframe()
     assert df["data_group"].iloc[0] == "demdiff"
+    assert df["uncertainty_level"].iloc[0] == 95
     assert df.shape[0] == 1
 
 

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -533,7 +533,7 @@ def test_convert_timeseries_to_annual_trends_up_sampling_throws_exception(
     example_timeseries_ingested.data.end_dates = np.array([2015.0])
     example_timeseries_ingested.data.changes = np.array([5.0])
     assert not example_timeseries_ingested.timeseries_is_annual_grid()
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         example_timeseries_ingested.convert_timeseries_to_annual_trends()
 
 
@@ -697,7 +697,7 @@ def test_apply_area_change_and_remove(example_timeseries_ingested):
 
 def test_apply_area_change_and_wrong_unit(example_timeseries_ingested):
     example_timeseries_ingested.unit = "gt"
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         example_timeseries_ingested.apply_or_remove_area_change(
             rgi_area_version=7, apply_area_change=True
         )
@@ -707,7 +707,7 @@ def test_apply_area_change_when_already_applied(example_timeseries_ingested):
     timeseries_area_change = example_timeseries_ingested.apply_or_remove_area_change(
         rgi_area_version=7, apply_area_change=True
     )
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         timeseries_area_change.apply_or_remove_area_change(
             rgi_area_version=7, apply_area_change=True
         )
@@ -715,19 +715,19 @@ def test_apply_area_change_when_already_applied(example_timeseries_ingested):
 
 def test_remove_area_change_when_already_removed(example_timeseries_ingested):
     assert not example_timeseries_ingested.area_change_applied
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         example_timeseries_ingested.apply_or_remove_area_change(
             rgi_area_version=7, apply_area_change=False
         )
 
 
-def test_raises_assertion_error_when_converting_to_gt_with_area_change_applied(
+def test_raises_value_error_when_converting_to_gt_with_area_change_applied(
     example_timeseries_ingested,
 ):
     timeseries_area_change = example_timeseries_ingested.apply_or_remove_area_change(
         rgi_area_version=7, apply_area_change=True
     )
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         timeseries_area_change.convert_timeseries_to_unit_gt(rgi_area_version=7)
 
 

--- a/tests/data/test_timeseries.py
+++ b/tests/data/test_timeseries.py
@@ -533,7 +533,10 @@ def test_convert_timeseries_to_annual_trends_up_sampling_throws_exception(
     example_timeseries_ingested.data.end_dates = np.array([2015.0])
     example_timeseries_ingested.data.changes = np.array([5.0])
     assert not example_timeseries_ingested.timeseries_is_annual_grid()
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"Timeseries needs to fit into annual grid",
+    ):
         example_timeseries_ingested.convert_timeseries_to_annual_trends()
 
 
@@ -697,7 +700,10 @@ def test_apply_area_change_and_remove(example_timeseries_ingested):
 
 def test_apply_area_change_and_wrong_unit(example_timeseries_ingested):
     example_timeseries_ingested.unit = "gt"
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"Area change should only be applied/removed to 'm' or 'mwe'",
+    ):
         example_timeseries_ingested.apply_or_remove_area_change(
             rgi_area_version=7, apply_area_change=True
         )
@@ -707,7 +713,10 @@ def test_apply_area_change_when_already_applied(example_timeseries_ingested):
     timeseries_area_change = example_timeseries_ingested.apply_or_remove_area_change(
         rgi_area_version=7, apply_area_change=True
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"Area change is already applied to current dataset",
+    ):
         timeseries_area_change.apply_or_remove_area_change(
             rgi_area_version=7, apply_area_change=True
         )
@@ -715,7 +724,10 @@ def test_apply_area_change_when_already_applied(example_timeseries_ingested):
 
 def test_remove_area_change_when_already_removed(example_timeseries_ingested):
     assert not example_timeseries_ingested.area_change_applied
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"Area change is not applied to current dataset",
+    ):
         example_timeseries_ingested.apply_or_remove_area_change(
             rgi_area_version=7, apply_area_change=False
         )
@@ -727,7 +739,10 @@ def test_raises_value_error_when_converting_to_gt_with_area_change_applied(
     timeseries_area_change = example_timeseries_ingested.apply_or_remove_area_change(
         rgi_area_version=7, apply_area_change=True
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot convert dataset to Gt\. Area change needs to be removed first",
+    ):
         timeseries_area_change.convert_timeseries_to_unit_gt(rgi_area_version=7)
 
 

--- a/tests/processing/test_process_global_results.py
+++ b/tests/processing/test_process_global_results.py
@@ -34,6 +34,7 @@ def example_catalogue():
         data_group=GLAMBIE_DATA_GROUPS["consensus"],
         data=data1,
         region=REGIONS["iceland"],
+        uncertainty_level=95,
         area_change_applied=True,
     )
     data2 = TimeseriesData(
@@ -52,6 +53,7 @@ def example_catalogue():
         data_group=GLAMBIE_DATA_GROUPS["consensus"],
         data=data2,
         region=REGIONS["svalbard"],
+        uncertainty_level=95,
         area_change_applied=True,
     )
     return DataCatalogue.from_list([ts1, ts2])


### PR DESCRIPTION
## 🚀 Type of Change
- [x] ✨ New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup
- [ ] ⚙️ Dependency upgrade
- [ ] 🚢 CI update

## 📝 Description

GlaMBIE-2 datasets in the bucket have different uncertainty levels (1-sigma and 2-sigma). This PR adds the functionality to handle this and to convert all uncertainties to 2-sigma (95%) before processing.

I did some regression tests:
- All GlaMBIE-1 datasets were submitted with sigma-2 uncertainties (95%) and the change has therefore not affected the GlaMBIE-1 results.
- The only output changed in the GlaMBIE-2 runs were the error columns of the results, which is to be expected due to the change.

## 🐝 Hive Card
https://app.hive.com/workspace/GNxP5GYvPWRvyG2Cr?actionId=zfSvkDMN4t8stdys6

## ✅ Checklist
- [x] My code follows the project’s style and guidelines.
- [x] I have considered whether adding any Jupyter notebooks is necessary and useful to others.
      (Reminder: notebooks are brittle since they are not covered by automated tests.)
- [x] I have considered the wider impact of changing shared components/libraries.
- [x] I have tested my changes locally.
- [x] I have updated relevant documentation (README, docs, comments).

## 📸 Screenshots (if applicable)
<!-- Add screenshots or recordings to help reviewers understand the changes -->
